### PR TITLE
Fix confirm's initial value

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -38,9 +38,7 @@ impl Confirm {
 
     /// Starts the prompt interaction.
     pub fn interact(&mut self) -> io::Result<bool> {
-        if self.initial_value {
-            self.input = true;
-        }
+        self.input = self.initial_value;
         <Self as PromptInteraction<bool>>::interact(self)
     }
 }

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -38,6 +38,9 @@ impl Confirm {
 
     /// Starts the prompt interaction.
     pub fn interact(&mut self) -> io::Result<bool> {
+        if self.initial_value {
+            self.input = true;
+        }
         <Self as PromptInteraction<bool>>::interact(self)
     }
 }


### PR DESCRIPTION
I noticed `.initial_value()` wasn't having any effect on confirmation prompts. With either value, the prompt would still have "No" selected.

```rust
let install = cliclack::confirm("Install dependencies?")
    .initial_value(true)  // <--- no effect
    .interact()?;

◆  Install dependencies?
│  ○ Yes  / ● No
```

```rust
let install = cliclack::confirm("Install dependencies?")
    .initial_value(false)  // <--- no effect
    .interact()?;

◆  Install dependencies?
│  ○ Yes  / ● No
```