### PR TITLE
Enable addition of items as a collection for 'select' and 'multiselect' components

### DIFF
--- a/examples/basic_dynamic_items.rs
+++ b/examples/basic_dynamic_items.rs
@@ -1,0 +1,39 @@
+use console::style;
+
+fn main() -> std::io::Result<()> {
+    cliclack::clear_screen()?;
+
+    cliclack::intro(style(" create-app ").on_cyan().black())?;
+
+    // This is the only difference between this snippet and examples/basic.rs
+    // You can supply your items dynamically, i.e. from a database or API.
+    let items_for_select = &[
+        ("ts", "TypeScript", ""),
+        ("js", "JavaScript", ""),
+        ("coffee", "CoffeeScript", "oh no"),
+    ];
+
+    let _selected_dynamic_item = cliclack::select(format!("Pick a project type"))
+        .initial_value("ts")
+        .items(items_for_select)
+        .interact()?;
+
+    let items_for_multiselect = &[
+        ("prettier", "Prettier", "recommended"),
+        ("eslint", "ESLint", "recommended"),
+        ("stylelint", "Stylelint", ""),
+        ("gh-action", "GitHub Action", ""),
+    ];
+
+    let _tools = cliclack::multiselect("Select additional tools")
+        .initial_values(vec!["prettier", "eslint"])
+        .items(items_for_multiselect)
+        .interact()?;
+
+    cliclack::outro(format!(
+        "Problems? {}\n",
+        style("https://example.com/issues").cyan().underlined()
+    ))?;
+
+    Ok(())
+}

--- a/examples/basic_dynamic_items.rs
+++ b/examples/basic_dynamic_items.rs
@@ -7,7 +7,7 @@ fn main() -> std::io::Result<()> {
 
     // This is the only difference between this snippet and examples/basic.rs
     // You can supply your items dynamically, i.e. from a database or API.
-    let items_for_select = &[
+    let items_for_select = vec![
         ("ts", "TypeScript", ""),
         ("js", "JavaScript", ""),
         ("coffee", "CoffeeScript", "oh no"),
@@ -15,7 +15,7 @@ fn main() -> std::io::Result<()> {
 
     let _selected_dynamic_item = cliclack::select(format!("Pick a project type"))
         .initial_value("ts")
-        .items(items_for_select)
+        .items(&items_for_select)
         .interact()?;
 
     let items_for_multiselect = &[

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -50,6 +50,14 @@ where
         self
     }
 
+    /// Adds multiple items to the list of options.
+    pub fn items(mut self, items: &[(T, impl Display, impl Display)]) -> Self {
+        for (value, label, hint) in items {
+            self = self.item(value.clone(), label, hint);
+        }
+        self
+    }
+
     /// Sets the initially selected values.
     pub fn initial_values(mut self, value: Vec<T>) -> Self {
         self.initial_values = Some(value);

--- a/src/select.rs
+++ b/src/select.rs
@@ -46,6 +46,14 @@ where
         self
     }
 
+    /// Adds multiple items to the list of options.
+    pub fn items(mut self, items: &[(T, impl Display, impl Display)]) -> Self {
+        for (value, label, hint) in items {
+            self = self.item(value.clone(), label, hint);
+        }
+        self
+    }
+
     /// Sets the initially selected item by value.
     pub fn initial_value(mut self, value: T) -> Self {
         self.initial_value = Some(value);


### PR DESCRIPTION
I was trying to solve this use case:
I have a config.json file from which I want to read a list of servers to which I want to connect. The user can use the multiselect/select component to select the items. But I didn't find a way to add multiple items dynamically, hence the PR.