### PR TITLE
Add support for Ctrl-C handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ indicatif = "0.17.5"
 once_cell = "1.18.0"
 textwrap = "0.16.0"
 zeroize = {version = "1.6.0", features = ["derive"]}
+
+[dev-dependencies]
+ctrlc = "3.4.2"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,6 +3,14 @@ use std::{thread, time::Duration};
 use console::style;
 
 fn main() -> std::io::Result<()> {
+    // Set a no-op Ctrl-C handler so that Ctrl-C results in a
+    // `term.read_key()` error instead of terminating the process. You can skip
+    // this step if you have your own Ctrl-C handler already set up.
+    //
+    // We cannot (easily) handle this at the library level due to
+    // https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.
+    ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
+
     cliclack::clear_screen()?;
 
     cliclack::intro(style(" create-app ").on_cyan().black())?;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,13 +3,14 @@ use std::{thread, time::Duration};
 use console::style;
 
 fn main() -> std::io::Result<()> {
-    // Set a no-op Ctrl-C handler so that Ctrl-C results in a
-    // `term.read_key()` error instead of terminating the process. You can skip
+    // Set a no-op Ctrl-C handler so that Ctrl-C results in
+    // `Esc` behavior because of a `term.read_key()` error
+    // instead of terminating the process. You can skip
     // this step if you have your own Ctrl-C handler already set up.
     //
     // We cannot (easily) handle this at the library level due to
     // https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.
-    ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
+    ctrlc::set_handler(move || {}).expect("setting Ctrl-C handler");
 
     cliclack::clear_screen()?;
 

--- a/examples/basic_dynamic_items.rs
+++ b/examples/basic_dynamic_items.rs
@@ -1,6 +1,14 @@
 use console::style;
 
 fn main() -> std::io::Result<()> {
+    // Set a no-op Ctrl-C handler so that Ctrl-C results in a
+    // `term.read_key()` error instead of terminating the process. You can skip
+    // this step if you have your own Ctrl-C handler already set up.
+    //
+    // We cannot (easily) handle this at the library level due to
+    // https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.
+    ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
+
     cliclack::clear_screen()?;
 
     cliclack::intro(style(" create-app ").on_cyan().black())?;

--- a/examples/basic_dynamic_items.rs
+++ b/examples/basic_dynamic_items.rs
@@ -1,13 +1,8 @@
 use console::style;
 
 fn main() -> std::io::Result<()> {
-    // Set a no-op Ctrl-C handler so that Ctrl-C results in a
-    // `term.read_key()` error instead of terminating the process. You can skip
-    // this step if you have your own Ctrl-C handler already set up.
-    //
-    // We cannot (easily) handle this at the library level due to
-    // https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.
-    ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
+    // Set a no-op Ctrl-C to make it behave as `Esc` (see the basic example).
+    ctrlc::set_handler(move || {}).expect("setting Ctrl-C handler");
 
     cliclack::clear_screen()?;
 

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -22,6 +22,14 @@ impl Theme for MagentaTheme {
 }
 
 fn main() -> std::io::Result<()> {
+    // Set a no-op Ctrl-C handler so that Ctrl-C results in a
+    // `term.read_key()` error instead of terminating the process. You can skip
+    // this step if you have your own Ctrl-C handler already set up.
+    //
+    // We cannot (easily) handle this at the library level due to
+    // https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.
+    ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
+
     set_theme(MagentaTheme);
 
     intro(style(" theme ").on_magenta().black())?;

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -22,13 +22,8 @@ impl Theme for MagentaTheme {
 }
 
 fn main() -> std::io::Result<()> {
-    // Set a no-op Ctrl-C handler so that Ctrl-C results in a
-    // `term.read_key()` error instead of terminating the process. You can skip
-    // this step if you have your own Ctrl-C handler already set up.
-    //
-    // We cannot (easily) handle this at the library level due to
-    // https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.
-    ctrlc::set_handler(move || {}).expect("Error setting Ctrl-C handler");
+     // Set a no-op Ctrl-C to make it behave as `Esc` (see the basic example).
+    ctrlc::set_handler(move || {}).expect("setting Ctrl-C handler");
 
     set_theme(MagentaTheme);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@
 //! ## Cancellation
 //!
 //! `Esc` cancels the prompt sequence with a nice message.
-//! `Ctrl+C` interrupts the session abruptly, it's handled inside of the
-//! `Term` crate and cannot be easily caught and rendered fancy.
+//! `Ctrl+C` will be handled gracefully (same as `Esc`) if you set up a Ctrl+C
+//! handler, eg. with the `ctrlc` crate.
 //!
 //! # Components
 //!
@@ -226,8 +226,8 @@ pub use select::Select;
 pub use spinner::Spinner;
 pub use validate::Validate;
 
-fn term_write(line: String) -> io::Result<()> {
-    Term::stderr().write_str(&line)
+fn term_write(line: impl Display) -> io::Result<()> {
+    Term::stderr().write_str(line.to_string().as_str())
 }
 
 /// Clears the terminal.


### PR DESCRIPTION
Fix https://github.com/fadeevab/cliclack/issues/7.

I was hoping that there would be a way to accomplish this without requiring any changes from user code, but I have not yet found a solution to https://github.com/Detegr/rust-ctrlc/issues/106#issuecomment-1887793468.

In any case, this PR fixes the issue such that Ctrl-C is now handled the same as Esc, assuming client code sets up a signal handler. Crucially it does not steal the user's cursor anymore.