### PR TITLE
Add support for Alt-Left/Right and Alt-Backspace editing

### DIFF
--- a/src/password.rs
+++ b/src/password.rs
@@ -62,6 +62,12 @@ impl PromptInteraction<String> for Password {
         Some(&mut self.input)
     }
 
+    fn allow_word_editing(&self) -> bool {
+        // Disallow word editing for password prompts so as not to reveal
+        // password structure.
+        false
+    }
+
     fn on(&mut self, event: &Event) -> State<String> {
         let Event::Key(key) = event;
 

--- a/src/prompt/cursor.rs
+++ b/src/prompt/cursor.rs
@@ -55,22 +55,18 @@ impl StringCursor {
         }
     }
 
-    pub fn move_word_left(&mut self) {
-        if self.cursor > 0 {
-            let jumps = word_jump_indices(&self.value);
-            let ix = jumps.binary_search(&self.cursor).unwrap_or_else(|i| i);
-            self.cursor = jumps[std::cmp::max(ix - 1, 0)];
-        }
+    pub fn move_left_by_word(&mut self) {
+        let jumps = word_jump_indices(&self.value);
+        let ix = jumps.binary_search(&self.cursor).unwrap_or_else(|i| i);
+        self.cursor = jumps[ix.saturating_sub(1)];
     }
 
-    pub fn move_word_right(&mut self) {
-        if self.cursor < self.value.len() {
-            let jumps = word_jump_indices(&self.value);
-            let ix = jumps
-                .binary_search(&self.cursor)
-                .map_or_else(|i| i, |i| i + 1);
-            self.cursor = jumps[std::cmp::min(ix, jumps.len() - 1)];
-        }
+    pub fn move_right_by_word(&mut self) {
+        let jumps = word_jump_indices(&self.value);
+        let ix = jumps
+            .binary_search(&self.cursor)
+            .map_or_else(|i| i, |i| i + 1);
+        self.cursor = jumps[std::cmp::min(ix, jumps.len().saturating_sub(1))];
     }
 
     pub fn move_home(&mut self) {
@@ -102,7 +98,7 @@ impl StringCursor {
         }
     }
 
-    pub fn delete_word_left(&mut self) {
+    pub fn delete_word_to_the_left(&mut self) {
         if self.cursor > 0 {
             let jumps = word_jump_indices(&self.value);
             let ix = jumps.binary_search(&self.cursor).unwrap_or_else(|x| x);

--- a/src/prompt/interaction.rs
+++ b/src/prompt/interaction.rs
@@ -114,19 +114,19 @@ pub trait PromptInteraction<T> {
                             Key::End => cursor.move_end(),
 
                             // Alt-Backspace
-                            Key::Char('\u{17}') if word_editing => cursor.delete_word_left(),
+                            Key::Char('\u{17}') if word_editing => cursor.delete_word_to_the_left(),
 
                             // Alt-ArrowLeft
                             Key::UnknownEscSeq(ref chars)
                                 if word_editing && chars.as_slice() == ['b'] =>
                             {
-                                cursor.move_word_left()
+                                cursor.move_left_by_word()
                             }
                             // Alt-ArrowRight
                             Key::UnknownEscSeq(ref chars)
                                 if word_editing && chars.as_slice() == ['f'] =>
                             {
-                                cursor.move_word_right()
+                                cursor.move_right_by_word()
                             }
 
                             _ => {}


### PR DESCRIPTION
Fix https://github.com/fadeevab/cliclack/issues/5.

This PR is built off of https://github.com/fadeevab/cliclack/pull/8, so it would be easiest to merge that one first. To review this diff, it may be easiest to look at the changes from https://github.com/fadeevab/cliclack/pull/9/commits/7e9b848caf594defd58d7288a4feebfdf39f8e23 only.