### PR TITLE
Fix display width calculation in cliclack::note prompt

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -68,7 +68,7 @@ fn main() -> std::io::Result<()> {
         }
     );
 
-    cliclack::note("Next steps.", next_steps)?;
+    cliclack::note("Next steps. 🌲🍉🐓", next_steps)?;
 
     cliclack::outro(format!(
         "Problems? {}\n",

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -495,7 +495,7 @@ pub trait Theme {
         let header = format!(
             "{symbol}  {prompt} {horizontal_bar}{corner}\n",
             horizontal_bar =
-                bar_color.apply_to(S_BAR_H.to_string().repeat(width - prompt.chars().count())),
+                bar_color.apply_to(S_BAR_H.to_string().repeat(width - display_width(prompt))),
             corner = bar_color.apply_to(S_CORNER_TOP_RIGHT),
         );
         #[allow(clippy::format_collect)]


### PR DESCRIPTION
I also modified the `basic.rs` example to make it a sort of test case.

Before:
<img width="1207" alt="Screenshot 2024-01-17 at 3 56 40 PM" src="https://github.com/fadeevab/cliclack/assets/226872/21ab968b-c80b-40d1-a8b5-f2f945c44398">

After:
<img width="1174" alt="Screenshot 2024-01-17 at 3 57 01 PM" src="https://github.com/fadeevab/cliclack/assets/226872/28b55b98-d88b-4aed-90aa-d7255c3a1ba5">
