### PR TITLE
Extend `Spinner`'s API with `error` and `cancel`

### DIFF
--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -1,0 +1,37 @@
+use std::io;
+
+use cliclack::{clear_screen, intro, log, outro, outro_cancel, spinner};
+use console::{style, Key, Term};
+
+fn main() -> std::io::Result<()> {
+    ctrlc::set_handler(move || {}).expect("setting Ctrl-C handler");
+
+    clear_screen()?;
+    intro(style(" spinner ").on_cyan().black())?;
+    log::remark("Press Esc, Enter, or Ctrl-C")?;
+
+    let mut spinner = spinner();
+    spinner.start("Installation");
+
+    let term = Term::stderr();
+    loop {
+        match term.read_key() {
+            Ok(Key::Escape) => {
+                spinner.cancel("Installation");
+                outro_cancel("Cancelled")?;
+            }
+            Ok(Key::Enter) => {
+                spinner.stop("Installation");
+                outro("Done!")?;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {
+                spinner.error("Installation");
+                outro_cancel("Interrupted")?;
+            }
+            _ => continue,
+        }
+        break;
+    }
+
+    Ok(())
+}

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, time::Duration};
 
 use indicatif::{ProgressBar, ProgressStyle};
 
-use crate::theme::THEME;
+use crate::{theme::THEME, ThemeState};
 
 /// A spinner that renders progress indication.
 ///
@@ -40,6 +40,28 @@ impl Spinner {
         // Workaround: the next line doesn't "jump" around while resizing the terminal.
         self.spinner
             .println(theme.format_spinner_stop(&message.to_string()));
+        self.spinner.finish_and_clear();
+    }
+
+    /// Makes the spinner stop with an error.
+    pub fn error(&mut self, message: impl Display) {
+        let theme = THEME.lock().unwrap();
+        let state = &ThemeState::Error("".into());
+
+        // Workaround: the next line doesn't "jump" around while resizing the terminal.
+        self.spinner
+            .println(theme.format_spinner_with_state(&message.to_string(), state));
+        self.spinner.finish_and_clear();
+    }
+
+    /// Cancel the spinner (stop with cancelling style).
+    pub fn cancel(&mut self, message: impl Display) {
+        let theme = THEME.lock().unwrap();
+        let state = &ThemeState::Cancel;
+
+        // Workaround: the next line doesn't "jump" around while resizing the terminal.
+        self.spinner
+            .println(theme.format_spinner_with_state(&message.to_string(), state));
         self.spinner.finish_and_clear();
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -475,6 +475,20 @@ pub trait Theme {
         )
     }
 
+    /// Returns the spinner with a final message in a specified state.
+    ///
+    /// It's not symmetric to [`Theme::format_spinner_start`] because of a workaround
+    /// for the [`indicatif::ProgressBar`] spinner behavior which disrupts
+    /// the line after the stop message reproduced while terminal resizing
+    /// (see [`Spinner::stop`](fn@crate::Spinner::stop)).
+    fn format_spinner_with_state(&self, msg: &str, state: &ThemeState) -> String {
+        format!(
+            "{symbol}  {msg}\n{bar}",
+            symbol = self.state_symbol(state),
+            bar = self.bar_color(&ThemeState::Submit).apply_to(S_BAR)
+        )
+    }
+
     /// Returns the spinner character sequence.
     fn spinner_chars(&self) -> String {
         S_SPINNER.to_string()


### PR DESCRIPTION
Solves a feature request #10 

```bash
cargo run --example spinner
```

Start
![image](https://github.com/fadeevab/cliclack/assets/5967447/492c7463-9740-424f-8a30-ac93251950eb)

Ctrl-C
![image](https://github.com/fadeevab/cliclack/assets/5967447/e8c7c3e6-db07-4f6b-a8fd-f724204f71ac)

Enter
![image](https://github.com/fadeevab/cliclack/assets/5967447/b14b3518-7b46-403b-bcea-c4c53bfecc51)

Escape
![image](https://github.com/fadeevab/cliclack/assets/5967447/0dc1bbff-e790-48f3-afbc-bfd600237087)
