### PR TITLE
Improvements to `Select`

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -8,16 +8,14 @@ use crate::{
     theme::THEME,
 };
 
-#[derive(Default)]
-pub struct RadioButton<T: Default> {
+pub struct RadioButton<T> {
     pub value: T,
     pub label: String,
     pub hint: String,
 }
 
 /// A prompt that asks for one selection from a list of options.
-#[derive(Default)]
-pub struct Select<T: Default> {
+pub struct Select<T> {
     prompt: String,
     items: Vec<RadioButton<T>>,
     cursor: usize,
@@ -26,13 +24,15 @@ pub struct Select<T: Default> {
 
 impl<T> Select<T>
 where
-    T: Default + Clone + Eq,
+    T: Clone + Eq,
 {
     /// Creates a new selection prompt.
     pub fn new(prompt: impl Display) -> Self {
         Self {
             prompt: prompt.to_string(),
-            ..Default::default()
+            items: Vec::new(),
+            cursor: 0,
+            initial_value: None,
         }
     }
 
@@ -74,7 +74,7 @@ where
     }
 }
 
-impl<T: Default + Clone> PromptInteraction<T> for Select<T> {
+impl<T: Clone> PromptInteraction<T> for Select<T> {
     fn on(&mut self, event: &Event) -> State<T> {
         let Event::Key(key) = event;
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -62,13 +62,12 @@ where
 
     /// Starts the prompt interaction.
     pub fn interact(&mut self) -> io::Result<T> {
-        for (i, item) in self.items.iter().enumerate() {
-            if let Some(initial_value) = &self.initial_value {
-                if initial_value == &item.value {
-                    self.cursor = i;
-                    break;
-                }
-            }
+        if let Some(initial_value) = &self.initial_value {
+            self.cursor = self
+                .items
+                .iter()
+                .position(|item| item.value == *initial_value)
+                .unwrap_or(self.cursor);
         }
         <Self as PromptInteraction<T>>::interact(self)
     }
@@ -101,15 +100,14 @@ impl<T: Clone> PromptInteraction<T> for Select<T> {
 
         let line1 = theme.format_header(&state.into(), &self.prompt);
 
-        let mut line2 = String::new();
-        for (i, item) in self.items.iter().enumerate() {
-            line2.push_str(&theme.format_select_item(
-                &state.into(),
-                self.cursor == i,
-                &item.label,
-                &item.hint,
-            ));
-        }
+        let line2: String = self
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                theme.format_select_item(&state.into(), self.cursor == i, &item.label, &item.hint)
+            })
+            .collect();
         let line3 = theme.format_footer(&state.into());
 
         line1 + &line2 + &line3


### PR DESCRIPTION
See the commit messages for individual changes and their explanations. In short:
1. Remove the `Default` trait constraint on `T`.
2. ~Remove the private `initial_value` field on `Select` by re-homing some of the logic.~
3. Replace for loops with stdlib `Iterator`-fu where appropriate.