### PR TITLE
Implement `ProgressBar` and `MultiProgress`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/fadeevab/cliclack"
 
 [dependencies]
-console = "0.15.7"
+console = "0.15.8"
 indicatif = "0.17.5"
 once_cell = "1.18.0"
 textwrap = "0.16.0"
@@ -22,3 +22,4 @@ zeroize = {version = "1.6.0", features = ["derive"]}
 
 [dev-dependencies]
 ctrlc = "3.4.2"
+rand = "0.8.5"

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -44,7 +44,7 @@ fn main() -> std::io::Result<()> {
             term.clear_line()?;
             term.move_cursor_up(1)?;
 
-            download.error("Downloading");
+            download.cancel("Downloading");
             outro_cancel("Interrupted")?;
             return Ok(());
         }

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,0 +1,62 @@
+use std::{sync::mpsc::channel, time::Duration};
+
+use cliclack::{clear_screen, intro, log::remark, outro, outro_cancel, progress_bar};
+use console::{style, Term};
+use rand::{thread_rng, Rng};
+
+enum Message {
+    Interrupt,
+}
+
+// Total number of bytes to simulate downloading.
+const TOTAL_BYTES: u64 = 5_000_000;
+
+fn main() -> std::io::Result<()> {
+    let (tx, rx) = channel();
+
+    // Set a no-op Ctrl-C handler which allows to catch
+    // `ErrorKind::Interrupted` error on `term.read_key()`.
+    ctrlc::set_handler(move || {
+        tx.send(Message::Interrupt).ok();
+    })
+    .expect("setting Ctrl-C handler");
+
+    // Clear the screen and print the header.
+    clear_screen()?;
+    intro(style(" download ").on_cyan().black())?;
+    remark("Press Ctrl-C")?;
+
+    // Create a new progress bar and set the text to "Installation".
+    let download = progress_bar(TOTAL_BYTES).with_template(
+        "{msg} [{elapsed_precise}] [{bar:30.cyan/blue}] {bytes}/{total_bytes} ({eta})",
+    );
+    download.start("Downloading, please wait...");
+
+    // Loop until the progress bar reaches the total number of bytes
+    while download.bar().position() < TOTAL_BYTES {
+        // Use a random timeout to simulate some work.
+        let timeout = Duration::from_millis(thread_rng().gen_range(10..150));
+
+        // Check if we received a message from the channel.
+        if let Ok(Message::Interrupt) = rx.recv_timeout(timeout) {
+            // Clear the garbage appearing because of Ctrl-C.
+            let term = Term::stderr();
+            term.clear_line()?;
+            term.move_cursor_up(1)?;
+
+            download.error("Downloading");
+            outro_cancel("Interrupted")?;
+            return Ok(());
+        }
+
+        // Increment the progress bar with a random number of bytes.
+        download.bar().inc(thread_rng().gen_range(1_000..200_000));
+    }
+
+    // Once we're done, we stop the progress bar and print the outro message.
+    // This removes the progress bar and prints the message to the terminal.
+    download.stop("Downloading");
+    outro("Done!")?;
+
+    Ok(())
+}

--- a/examples/multiprogress.rs
+++ b/examples/multiprogress.rs
@@ -28,8 +28,8 @@ fn main() -> std::io::Result<()> {
     // Create a new progress bar and set the text to "Installation".
     let multi = multi_progress("Doing stuff...");
 
-    let pb1 = multi.add(progress_bar(100));
-    let pb2 = multi.add(progress_bar(100));
+    let pb1 = multi.add(progress_bar(500));
+    let pb2 = multi.add(progress_bar(500));
 
     pb1.start("Downloading files...");
     pb2.start("Copying files...");
@@ -46,8 +46,9 @@ fn main() -> std::io::Result<()> {
             term.clear_line()?;
             term.move_cursor_up(1)?;
 
-            pb1.cancel("Copying files");
-            pb2.cancel("Downloading files");
+            pb1.cancel(format!("{} Copying files", style("✘").red()));
+            pb2.cancel(format!("{} Downloading files", style("✘").red()));
+            multi.stop();
             outro_cancel("Interrupted")?;
             return Ok(());
         }
@@ -55,13 +56,13 @@ fn main() -> std::io::Result<()> {
         if pb1.bar().position() < pb1.bar().length().unwrap() {
             pb1.bar().inc(thread_rng().gen_range(1..20));
         } else if !pb1.bar().is_finished() {
-            pb1.stop(format!("{} {}", style("✔").green(), "Copying files"));
+            pb1.stop(format!("{} Copying files", style("✔").green()));
         }
 
         if pb2.bar().position() < pb2.bar().length().unwrap() {
             pb2.bar().inc(thread_rng().gen_range(1..13));
         } else if !pb2.bar().is_finished() {
-            pb2.stop(format!("{} {}", style("✔").green(), "Downloading files"));
+            pb2.stop(format!("{} Downloading files", style("✔").green()));
         }
     }
 

--- a/examples/multiprogress.rs
+++ b/examples/multiprogress.rs
@@ -46,8 +46,8 @@ fn main() -> std::io::Result<()> {
             term.clear_line()?;
             term.move_cursor_up(1)?;
 
-            pb1.cancel(format!("{} Copying files", style("✘").red()));
-            pb2.cancel(format!("{} Downloading files", style("✘").red()));
+            pb1.cancel(format!("{}  Copying files", style("✘").red()));
+            pb2.cancel(format!("{}  Downloading files", style("✘").red()));
             multi.stop();
             outro_cancel("Interrupted")?;
             return Ok(());
@@ -56,13 +56,13 @@ fn main() -> std::io::Result<()> {
         if pb1.bar().position() < pb1.bar().length().unwrap() {
             pb1.bar().inc(thread_rng().gen_range(1..20));
         } else if !pb1.bar().is_finished() {
-            pb1.stop(format!("{} Copying files", style("✔").green()));
+            pb1.stop(format!("{}  Copying files", style("✔").green()));
         }
 
         if pb2.bar().position() < pb2.bar().length().unwrap() {
             pb2.bar().inc(thread_rng().gen_range(1..13));
         } else if !pb2.bar().is_finished() {
-            pb2.stop(format!("{} Downloading files", style("✔").green()));
+            pb2.stop(format!("{}  Downloading files", style("✔").green()));
         }
     }
 

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -1,0 +1,57 @@
+use std::{sync::mpsc::channel, time::Duration};
+
+use cliclack::{clear_screen, intro, log::remark, outro, outro_cancel, progress_bar};
+use console::{style, Term};
+use rand::{thread_rng, Rng};
+
+enum Message {
+    Interrupt,
+}
+
+fn main() -> std::io::Result<()> {
+    let (tx, rx) = channel();
+
+    // Set a no-op Ctrl-C handler which allows to catch
+    // `ErrorKind::Interrupted` error on `term.read_key()`.
+    ctrlc::set_handler(move || {
+        tx.send(Message::Interrupt).ok();
+    })
+    .expect("setting Ctrl-C handler");
+
+    // Clear the screen and print the header.
+    clear_screen()?;
+    intro(style(" progress bar ").on_cyan().black())?;
+    remark("Press Ctrl-C")?;
+
+    // Create a new progress bar and set the text to "Installation".
+    let progress = progress_bar(100);
+    progress.start("Copying files...");
+
+    // Simulate doing some stuff....
+    for _ in 0..100 {
+        // Use a random timeout to simulate some work.
+        let timeout = Duration::from_millis(thread_rng().gen_range(10..75));
+
+        // Check if we received a message from the channel.
+        if let Ok(Message::Interrupt) = rx.recv_timeout(timeout) {
+            // Clear the garbage appearing because of Ctrl-C.
+            let term = Term::stderr();
+            term.clear_line()?;
+            term.move_cursor_up(1)?;
+
+            progress.error("Copying files");
+            outro_cancel("Interrupted")?;
+            return Ok(());
+        }
+
+        // Otherwise, we increase the progress bar by the delta 1.
+        progress.bar().inc(1);
+    }
+
+    // Once we're done, we stop the progress bar and print the outro message.
+    // This removes the progress bar and prints the message to the terminal.
+    progress.stop("Copying files");
+    outro("Done!")?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ mod confirm;
 mod input;
 mod multiselect;
 mod password;
+mod progress;
 mod prompt;
 mod select;
 mod spinner;
@@ -210,6 +211,7 @@ mod theme;
 mod validate;
 
 use console::Term;
+use progress::ProgressBar;
 use std::fmt::Display;
 use std::io;
 
@@ -306,6 +308,13 @@ pub fn confirm(prompt: impl Display) -> Confirm {
 /// See [`Spinner`] for chainable methods.
 pub fn spinner() -> Spinner {
     Spinner::default()
+}
+
+/// Constructs a new [`ProgressBar`] prompt.
+///
+/// See [`ProgressBar`] for chainable methods.
+pub fn progress_bar(len: u64) -> ProgressBar {
+    ProgressBar::new(len)
 }
 
 /// Prints a note message.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@
 
 mod confirm;
 mod input;
+mod multiprogress;
 mod multiselect;
 mod password;
 mod progress;
@@ -211,6 +212,7 @@ mod theme;
 mod validate;
 
 use console::Term;
+use multiprogress::MultiProgress;
 use progress::ProgressBar;
 use std::fmt::Display;
 use std::io;
@@ -315,6 +317,13 @@ pub fn spinner() -> Spinner {
 /// See [`ProgressBar`] for chainable methods.
 pub fn progress_bar(len: u64) -> ProgressBar {
     ProgressBar::new(len)
+}
+
+/// Constructs a new [`MultiProgressBar`] prompt.
+///
+/// See [`MultiProgressBar`] for chainable methods.
+pub fn multi_progress(prompt: impl Display) -> MultiProgress {
+    MultiProgress::new(prompt)
 }
 
 /// Prints a note message.

--- a/src/multiprogress.rs
+++ b/src/multiprogress.rs
@@ -1,0 +1,82 @@
+use std::{
+    fmt::Display,
+    sync::{Arc, RwLock},
+};
+
+use console::Term;
+
+use crate::{progress::ProgressBar, theme::THEME, ThemeState};
+
+const HEADER_HEIGHT: usize = 2;
+
+/// A spinner + progress bar that renders progress indication.
+///
+/// Implemented via theming of [`indicatif::ProgressBar`](https://docs.rs/indicatif).
+pub struct MultiProgress {
+    multi: indicatif::MultiProgress,
+    bars: Arc<RwLock<Vec<ProgressBar>>>,
+    prompt: String,
+}
+
+impl MultiProgress {
+    /// Creates a new progress bar with a given length.
+    pub fn new(prompt: impl Display) -> Self {
+        let theme = THEME.lock().unwrap();
+        let multi = indicatif::MultiProgress::new();
+
+        // HEADER_HEIGHT: 2 lines.
+        let header =
+            theme.format_header(&ThemeState::Active, (prompt.to_string() + "\n ").trim_end());
+
+        multi.println(header).ok();
+
+        Self {
+            multi,
+            bars: Default::default(),
+            prompt: prompt.to_string(),
+        }
+    }
+
+    /// Starts the progress bar.
+    pub fn add(&self, pb: ProgressBar) -> ProgressBar {
+        // Unset the last flag for all other progress bars: it affects rendering.
+        for bar in self.bars.write().unwrap().iter_mut() {
+            bar.options().last = false;
+        }
+
+        // Attention: deconstructing `pb` to avoid borrowing `pb.bar` twice.
+        let ProgressBar { bar, options } = pb;
+        let bar = self.multi.add(bar);
+        {
+            let mut options = options.write().unwrap();
+            options.grouped = true;
+            options.last = true;
+        }
+
+        let pb = ProgressBar { bar, options };
+        self.bars.write().unwrap().push(pb.clone());
+        pb
+    }
+
+    pub fn stop(&self) {
+        let term = Term::stderr();
+
+        let height = self.bars.write().unwrap().len() + HEADER_HEIGHT;
+        term.clear_last_lines(height).ok();
+
+        let state = &ThemeState::Submit;
+
+        term.write_str(
+            &THEME
+                .lock()
+                .unwrap()
+                .format_header(state, (self.prompt.clone() + "\n ").trim_end()),
+        )
+        .ok();
+
+        for bar in self.bars.write().unwrap().iter() {
+            let message = bar.options().message.as_ref().unwrap().clone();
+            bar.println(message, state);
+        }
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,35 +1,47 @@
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    sync::{Arc, RwLock, RwLockWriteGuard},
+};
 
 use indicatif::ProgressStyle;
 
 use crate::{theme::THEME, ThemeState};
 
+#[derive(Default)]
+pub(crate) struct ProgressBarOptions {
+    pub template: String,
+    pub message: Option<String>,
+    pub grouped: bool,
+    pub last: bool,
+}
+
 /// A spinner + progress bar that renders progress indication.
 ///
 /// Implemented via theming of [`indicatif::ProgressBar`](https://docs.rs/indicatif).
+#[derive(Clone)]
 pub struct ProgressBar {
-    bar: indicatif::ProgressBar,
-    template: String,
+    pub(crate) bar: indicatif::ProgressBar,
+    pub(crate) options: Arc<RwLock<ProgressBarOptions>>,
 }
 
 impl ProgressBar {
     /// Creates a new progress bar with a given length.
     pub fn new(len: u64) -> Self {
-        let theme = THEME.lock().unwrap();
-        let bar = indicatif::ProgressBar::new(len);
-        Self {
-            bar,
-            template: theme.default_progress_template(),
-        }
+        let this = Self {
+            bar: indicatif::ProgressBar::new(len),
+            options: Default::default(),
+        };
+
+        this.options().template = THEME.lock().unwrap().default_progress_template();
+
+        this
     }
 
     /// Sets the template string for the progress bar according to
     /// [`indicatif::ProgressStyle`](https://docs.rs/indicatif/latest/indicatif/#templates).
     pub fn with_template(self, template: &str) -> Self {
-        Self {
-            template: template.into(),
-            ..self
-        }
+        self.options().template = template.to_string();
+        self
     }
 
     /// Returns a reference to the underlying progress bar to give access to its API.
@@ -40,46 +52,87 @@ impl ProgressBar {
     /// Starts the progress bar.
     pub fn start(&self, message: impl Display) {
         let theme = THEME.lock().unwrap();
+        let state = &ThemeState::Active;
+        let options = self.options();
 
         self.bar.set_style(
-            ProgressStyle::with_template(&theme.format_progress_start(&self.template))
-                .unwrap()
-                .tick_chars(&theme.spinner_chars())
-                .progress_chars(&theme.progress_chars()),
+            ProgressStyle::with_template(&theme.format_progress_start(
+                &options.template,
+                options.grouped,
+                options.last,
+                state,
+            ))
+            .unwrap()
+            .tick_chars(&theme.spinner_chars())
+            .progress_chars(&theme.progress_chars()),
         );
 
         self.bar.set_message(message.to_string());
     }
 
-    /// Stops the spinner.
+    /// Stops the progress bar.
     pub fn stop(&self, message: impl Display) {
-        let theme = THEME.lock().unwrap();
+        let state = if !self.options().grouped {
+            ThemeState::Submit
+        } else {
+            ThemeState::Active
+        };
 
-        // Workaround: the next line doesn't "jump" around while resizing the terminal.
-        self.bar
-            .println(theme.format_spinner_stop(&message.to_string()));
-        self.bar.finish_and_clear();
+        self.println(message.to_string(), &state);
+        self.preserve_finish_and_clear(message);
     }
 
     /// Makes the spinner stop with an error.
     pub fn error(&self, message: impl Display) {
-        let theme = THEME.lock().unwrap();
-        let state = &ThemeState::Error("".into());
+        let state = if !self.options().grouped {
+            ThemeState::Error("".into())
+        } else {
+            ThemeState::Active
+        };
 
-        // Workaround: the next line doesn't "jump" around while resizing the terminal.
-        self.bar
-            .println(theme.format_spinner_with_state(&message.to_string(), state));
-        self.bar.finish_and_clear();
+        self.println(message.to_string(), &state);
+        self.preserve_finish_and_clear(message);
     }
 
     /// Cancel the spinner (stop with cancelling style).
     pub fn cancel(&self, message: impl Display) {
+        let state = if !self.options().grouped {
+            ThemeState::Cancel
+        } else {
+            ThemeState::Active
+        };
+
+        self.println(message.to_string(), &state);
+        self.preserve_finish_and_clear(message);
+    }
+
+    /// Accesses the options for writing (a convenience function).
+    #[inline]
+    pub(crate) fn options(&self) -> RwLockWriteGuard<'_, ProgressBarOptions> {
+        self.options.write().unwrap()
+    }
+
+    /// Redraws the progress bar with a new message.
+    ///
+    /// The method is semi-open for multi-progress bar purposes.
+    pub(crate) fn println(&self, message: impl Display, state: &ThemeState) {
         let theme = THEME.lock().unwrap();
-        let state = &ThemeState::Cancel;
+        let options = self.options();
+
+        let msg = theme.format_progress_with_state(
+            &message.to_string(),
+            options.grouped,
+            options.last,
+            state,
+        );
 
         // Workaround: the next line doesn't "jump" around while resizing the terminal.
-        self.bar
-            .println(theme.format_spinner_with_state(&message.to_string(), state));
+        self.bar.println(msg);
+    }
+
+    /// Preserves the message for a multi-progress bar and clears the bar.
+    fn preserve_finish_and_clear(&self, message: impl Display) {
+        self.options().message = Some(message.to_string());
         self.bar.finish_and_clear();
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -72,6 +72,10 @@ impl ProgressBar {
 
     /// Stops the progress bar.
     pub fn stop(&self, message: impl Display) {
+        if self.options().message.is_some() {
+            return;
+        }
+
         let state = if !self.options().grouped {
             ThemeState::Submit
         } else {
@@ -84,6 +88,10 @@ impl ProgressBar {
 
     /// Makes the spinner stop with an error.
     pub fn error(&self, message: impl Display) {
+        if self.options().message.is_some() {
+            return;
+        }
+
         let state = if !self.options().grouped {
             ThemeState::Error("".into())
         } else {
@@ -96,6 +104,10 @@ impl ProgressBar {
 
     /// Cancel the spinner (stop with cancelling style).
     pub fn cancel(&self, message: impl Display) {
+        if self.options().message.is_some() {
+            return;
+        }
+
         let state = if !self.options().grouped {
             ThemeState::Cancel
         } else {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,87 @@
+use std::fmt::Display;
+
+use indicatif::ProgressStyle;
+
+use crate::{theme::THEME, ThemeState};
+
+/// A spinner + progress bar that renders progress indication using current/total
+/// semantics. If you're looking for a download bar (or a bar that deals with
+/// bytes and formatting of bytes/KB/MB/GB, etc.), see [`DownloadBar`](crate::DownloadBar).
+///
+/// Implemented via theming of [`indicatif::ProgressBar`](https://docs.rs/indicatif).
+pub struct ProgressBar {
+    bar: indicatif::ProgressBar,
+    template: String,
+}
+
+impl ProgressBar {
+    /// Creates a new progress bar with a given length.
+    pub fn new(len: u64) -> Self {
+        let theme = THEME.lock().unwrap();
+        let bar = indicatif::ProgressBar::new(len);
+        Self {
+            bar,
+            template: theme.default_progress_template(),
+        }
+    }
+
+    /// Sets the template string for the progress bar according to
+    /// [`indicatif::ProgressStyle`](https://docs.rs/indicatif/latest/indicatif/#templates).
+    pub fn with_template(self, template: &str) -> Self {
+        Self {
+            template: template.into(),
+            ..self
+        }
+    }
+
+    /// Returns a reference to the underlying progress bar to give access to its API.
+    pub fn bar(&self) -> &indicatif::ProgressBar {
+        &self.bar
+    }
+
+    /// Starts the progress bar.
+    pub fn start(&self, message: impl Display) {
+        let theme = THEME.lock().unwrap();
+
+        self.bar.set_style(
+            ProgressStyle::with_template(&theme.format_progress_start(&self.template))
+                .unwrap()
+                .tick_chars(&theme.spinner_chars())
+                .progress_chars(&theme.progress_chars()),
+        );
+
+        self.bar.set_message(message.to_string());
+    }
+
+    /// Stops the spinner.
+    pub fn stop(&self, message: impl Display) {
+        let theme = THEME.lock().unwrap();
+
+        // Workaround: the next line doesn't "jump" around while resizing the terminal.
+        self.bar
+            .println(theme.format_spinner_stop(&message.to_string()));
+        self.bar.finish_and_clear();
+    }
+
+    /// Makes the spinner stop with an error.
+    pub fn error(&self, message: impl Display) {
+        let theme = THEME.lock().unwrap();
+        let state = &ThemeState::Error("".into());
+
+        // Workaround: the next line doesn't "jump" around while resizing the terminal.
+        self.bar
+            .println(theme.format_spinner_with_state(&message.to_string(), state));
+        self.bar.finish_and_clear();
+    }
+
+    /// Cancel the spinner (stop with cancelling style).
+    pub fn cancel(&self, message: impl Display) {
+        let theme = THEME.lock().unwrap();
+        let state = &ThemeState::Cancel;
+
+        // Workaround: the next line doesn't "jump" around while resizing the terminal.
+        self.bar
+            .println(theme.format_spinner_with_state(&message.to_string(), state));
+        self.bar.finish_and_clear();
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,9 +4,7 @@ use indicatif::ProgressStyle;
 
 use crate::{theme::THEME, ThemeState};
 
-/// A spinner + progress bar that renders progress indication using current/total
-/// semantics. If you're looking for a download bar (or a bar that deals with
-/// bytes and formatting of bytes/KB/MB/GB, etc.), see [`DownloadBar`](crate::DownloadBar).
+/// A spinner + progress bar that renders progress indication.
 ///
 /// Implemented via theming of [`indicatif::ProgressBar`](https://docs.rs/indicatif).
 pub struct ProgressBar {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -32,6 +32,7 @@ const S_WARN: Emoji = Emoji("▲", "!");
 const S_ERROR: Emoji = Emoji("■", "x");
 
 const S_SPINNER: Emoji = Emoji("◒◐◓◑", "•oO0");
+const S_PROGRESS: Emoji = Emoji("■□", "#-");
 
 /// The state of the prompt rendering.
 pub enum ThemeState {
@@ -469,6 +470,16 @@ pub trait Theme {
         )
     }
 
+    /// Returns the progress bar template.
+    fn default_progress_template(&self) -> String {
+        "{msg} [{elapsed_precise}] {bar:30.magenta} ({pos}/{len})".into()
+    }
+
+    /// Returns the progress bar start style for the [`indicatif::ProgressBar`].
+    fn format_progress_start(&self, template: &str) -> String {
+        format!("{{spinner:.magenta}}  {template}")
+    }
+
     /// Returns the spinner start style for the [`indicatif::ProgressBar`].
     fn format_spinner_start(&self) -> String {
         "{spinner:.magenta}  {msg}".into()
@@ -531,6 +542,11 @@ pub trait Theme {
         S_SPINNER.to_string()
     }
 
+    /// Returns the progress bar character sequence.
+    fn progress_chars(&self) -> String {
+        S_PROGRESS.to_string()
+    }
+
     /// Returns the multiline note message rendering, taking into account whether
     /// or not it's an inline vs. outro note.
     fn format_note_generic(&self, is_outro: bool, prompt: &str, message: &str) -> String {
@@ -560,7 +576,7 @@ pub trait Theme {
         );
 
         // Render the body, with multi-line support.
-        #[allow(clippy::format_collect)] 
+        #[allow(clippy::format_collect)]
         let body = message
             .lines()
             .map(|line| {


### PR DESCRIPTION
Co-authored-by: Cyle Witruk

@cylewitruk I've played around with `ProgressBar`, and this is how I see the code and design aiming towards the `MultiProgressBar`, the API of which is more complex. It should look more like you suggested, but the implementation should be different.

Note: The "move cursor up by 1" is really a corner case which happens because ^C is echoed to a terminal. It doesn't happen in a plenty of cases, e.g. when the terminal is in raw mode, or the process is interrupted by a signal.

![image](https://github.com/fadeevab/cliclack/assets/5967447/1ce8805f-5f97-4bcc-b12c-7350802efe17)
![image](https://github.com/fadeevab/cliclack/assets/5967447/0e0431a4-295f-4071-bc57-14ace14cb5db)
![image](https://github.com/fadeevab/cliclack/assets/5967447/16e42f4a-cdf4-46a8-aa36-fa028a24ac8c)
