### PR TITLE
Implement filter_mode for both select and multiselect prompts

### DIFF
--- a/examples/filter.rs
+++ b/examples/filter.rs
@@ -1,6 +1,6 @@
-use cliclack::select;
+use cliclack::{outro, select};
 
-fn main() {
+fn main() -> std::io::Result<()> {
     let selected = select("Select a word")
         .item("hello", "hello", "hi")
         .item("world", "world", "world")
@@ -13,9 +13,9 @@ fn main() {
             "hello how are YOU",
         )
         .filter_mode()
-        .interact();
+        .interact()?;
 
-    if let Ok(val) = selected {
-        println!("you chose: {}", val);
-    }
+    outro(format!("You chose: {selected}"))?;
+
+    Ok(())
 }

--- a/examples/filter.rs
+++ b/examples/filter.rs
@@ -15,7 +15,16 @@ fn main() -> std::io::Result<()> {
         .filter_mode()
         .interact()?;
 
-    outro(format!("You chose: {selected}"))?;
+    let tools = cliclack::multiselect("Select additional tools")
+        .initial_values(vec!["prettier", "eslint"])
+        .item("prettier", "Prettier", "recommended")
+        .item("eslint", "ESLint", "recommended")
+        .item("stylelint", "Stylelint", "")
+        .item("gh-action", "GitHub Action", "")
+        .filter_mode()
+        .interact()?;
+
+    outro(format!("You chose: {selected}, then {}", tools.join(", ")))?;
 
     Ok(())
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -44,11 +44,11 @@ impl<I: LabeledItem + Clone> FilteredView<I> {
         }
 
         match key {
-            // Need further processing of simple up and down actions.
+            // Need further processing of simple "up" and "down" actions.
             Key::ArrowDown | Key::ArrowUp => None,
-            // Need moving up and down the list if no input provided.
+            // Need moving up and down if no input provided.
             Key::ArrowLeft | Key::ArrowRight if self.input.is_empty() => None,
-            // Need submitting of the selected item.
+            // Need to submit the selected item.
             Key::Enter if !self.items.is_empty() => None,
             // Otherwise, no items found.
             Key::Enter => Some(State::Error("No items".into())),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,104 @@
+use std::{cell::RefCell, rc::Rc};
+
+use console::Key;
+
+use crate::prompt::{cursor::StringCursor, interaction::State};
+
+pub(crate) trait LabeledItem {
+    fn label(&self) -> &str;
+}
+
+pub(crate) struct FilteredView<I: LabeledItem> {
+    enabled: bool,
+    input: StringCursor,
+    items: Vec<Rc<RefCell<I>>>,
+}
+
+impl<I: LabeledItem> Default for FilteredView<I> {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            input: StringCursor::default(),
+            items: vec![],
+        }
+    }
+}
+
+impl<I: LabeledItem + Clone> FilteredView<I> {
+    pub fn enable(&mut self) {
+        self.enabled = true;
+    }
+
+    pub fn set(&mut self, items: Vec<Rc<RefCell<I>>>) {
+        self.items = items;
+    }
+
+    pub fn items(&self) -> &[Rc<RefCell<I>>] {
+        &self.items
+    }
+
+    pub fn on<T>(&mut self, key: &Key, all_items: Vec<Rc<RefCell<I>>>) -> Option<State<T>> {
+        if !self.enabled {
+            // Pass over the control.
+            return None;
+        }
+
+        match key {
+            // Need further processing of simple up and down actions.
+            Key::ArrowDown | Key::ArrowUp => None,
+            // Need moving up and down the list if no input provided.
+            Key::ArrowLeft | Key::ArrowRight if self.input.is_empty() => None,
+            // Need submitting of the selected item.
+            Key::Enter if !self.items.is_empty() => None,
+            // Otherwise, no items found.
+            Key::Enter => Some(State::Error("No items".into())),
+            // Ignore spaces passing through.
+            Key::Char(' ') => {
+                self.input.delete_left();
+                None
+            }
+            // Refresh the filtered items for the rest of the keys.
+            _ if !self.input.is_empty() => {
+                let input_lower = self.input.to_string();
+                let filter_words: Vec<_> = input_lower.split_whitespace().collect();
+
+                let mut filtered_and_scored_items: Vec<_> = all_items
+                    .into_iter()
+                    .map(|item| {
+                        let label = item.borrow().label().to_lowercase();
+                        let input = self.input.to_string().to_lowercase();
+                        let similarity = strsim::jaro_winkler(&label, &input);
+                        let bonus = filter_words
+                            .iter()
+                            .all(|word| label.contains(&word.to_lowercase()))
+                            as usize as f64;
+                        (similarity + bonus, item)
+                    })
+                    .filter(|(similarity, _)| *similarity > 0.6)
+                    .collect();
+
+                filtered_and_scored_items.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+
+                self.items = filtered_and_scored_items
+                    .into_iter()
+                    .map(|(_, item)| item)
+                    .collect();
+
+                Some(State::Active)
+            }
+            // Reset the items to the original list.
+            _ => {
+                self.items = all_items.to_vec();
+                Some(State::Active)
+            }
+        }
+    }
+
+    pub fn input(&mut self) -> Option<&mut StringCursor> {
+        if !self.enabled {
+            return None;
+        }
+
+        Some(&mut self.input)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@
 #![warn(missing_docs, unused_qualifications)]
 
 mod confirm;
+mod filter;
 mod input;
 mod multiprogress;
 mod multiselect;

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -1,13 +1,19 @@
-use std::fmt::Display;
+use std::cell::RefCell;
 use std::io;
+use std::{fmt::Display, rc::Rc};
 
 use console::Key;
 
 use crate::{
-    prompt::interaction::{Event, PromptInteraction, State},
+    filter::{FilteredView, LabeledItem},
+    prompt::{
+        cursor::StringCursor,
+        interaction::{Event, PromptInteraction, State},
+    },
     theme::THEME,
 };
 
+#[derive(Clone)]
 struct Checkbox<T> {
     value: T,
     label: String,
@@ -15,13 +21,20 @@ struct Checkbox<T> {
     selected: bool,
 }
 
+impl<T> LabeledItem for Checkbox<T> {
+    fn label(&self) -> &str {
+        &self.label
+    }
+}
+
 /// A prompt that asks for one or more selections from a list of options.
 pub struct MultiSelect<T> {
     prompt: String,
-    items: Vec<Checkbox<T>>,
+    items: Vec<Rc<RefCell<Checkbox<T>>>>,
     cursor: usize,
     initial_values: Option<Vec<T>>,
     required: bool,
+    filter: FilteredView<Checkbox<T>>,
 }
 
 impl<T> MultiSelect<T>
@@ -36,17 +49,18 @@ where
             cursor: 0,
             initial_values: None,
             required: true,
+            filter: FilteredView::default(),
         }
     }
 
     /// Adds an item to the list of options.
     pub fn item(mut self, value: T, label: impl Display, hint: impl Display) -> Self {
-        self.items.push(Checkbox {
+        self.items.push(Rc::new(RefCell::new(Checkbox {
             value,
             label: label.to_string(),
             hint: hint.to_string(),
             selected: false,
-        });
+        })));
         self
     }
 
@@ -71,6 +85,12 @@ where
         self
     }
 
+    /// Enable the filter mode.
+    pub fn filter_mode(mut self) -> Self {
+        self.filter.enable();
+        self
+    }
+
     /// Starts the prompt interaction.
     pub fn interact(&mut self) -> io::Result<Vec<T>> {
         if self.items.is_empty() {
@@ -81,11 +101,12 @@ where
         }
         if let Some(initial_values) = &self.initial_values {
             for item in self.items.iter_mut() {
-                if initial_values.contains(&item.value) {
-                    item.selected = true;
+                if initial_values.contains(&item.borrow().value) {
+                    item.borrow_mut().selected = true;
                 }
             }
         }
+        self.filter.set(self.items.to_vec());
         <Self as PromptInteraction<Vec<T>>>::interact(self)
     }
 }
@@ -94,6 +115,13 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
     fn on(&mut self, event: &Event) -> State<Vec<T>> {
         let Event::Key(key) = event;
 
+        if let Some(state) = self.filter.on(key, self.items.clone()) {
+            if self.filter.items().is_empty() || self.cursor > self.filter.items().len() - 1 {
+                self.cursor = 0;
+            }
+            return state;
+        }
+
         match key {
             Key::ArrowLeft | Key::ArrowUp => {
                 if self.cursor > 0 {
@@ -101,17 +129,20 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
                 }
             }
             Key::ArrowRight | Key::ArrowDown => {
-                if self.cursor < self.items.len() - 1 {
+                if !self.filter.items().is_empty() && self.cursor < self.filter.items().len() - 1 {
                     self.cursor += 1;
                 }
             }
             Key::Char(' ') => {
-                self.items[self.cursor].selected = !self.items[self.cursor].selected;
+                let mut item = self.filter.items()[self.cursor].borrow_mut();
+                item.selected = !item.selected;
             }
             Key::Enter => {
                 let selected_items = self
-                    .items
+                    .filter
+                    .items()
                     .iter()
+                    .map(|item| item.borrow())
                     .filter(|item| item.selected)
                     .map(|item| item.value.clone())
                     .collect::<Vec<_>>();
@@ -131,11 +162,20 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
     fn render(&mut self, state: &State<Vec<T>>) -> String {
         let theme = THEME.lock().unwrap();
 
-        let line1 = theme.format_header(&state.into(), &self.prompt);
+        let header = theme.format_header(&state.into(), &self.prompt);
 
-        let mut line2 = String::new();
-        for (i, item) in self.items.iter().enumerate() {
-            line2.push_str(&theme.format_multiselect_item(
+        let filter_line = if let Some(input) = self.filter.input() {
+            match state {
+                State::Submit(_) | State::Cancel => "".to_string(),
+                _ => theme.format_input(&state.into(), input),
+            }
+        } else {
+            "".to_string()
+        };
+
+        let mut items_render = String::new();
+        for (i, item) in self.filter.items().iter().map(|i| i.borrow()).enumerate() {
+            items_render.push_str(&theme.format_multiselect_item(
                 &state.into(),
                 item.selected,
                 i == self.cursor,
@@ -143,9 +183,14 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
                 &item.hint,
             ));
         }
-        let line3 = theme.format_footer(&state.into());
+        let footer = theme.format_footer(&state.into());
 
-        line1 + &line2 + &line3
+        header + &filter_line + &items_render + &footer
+    }
+
+    /// Enable handling of the input in the filter mode.
+    fn input(&mut self) -> Option<&mut StringCursor> {
+        self.filter.input()
     }
 }
 

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -205,7 +205,10 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
         let footer = if not_rendered_items > 0 {
             theme.format_footer_with_message(
                 &state.into(),
-                &format!("{} selected items hidden", not_rendered_items),
+                &format!(
+                    "{not_rendered_items} selected item{s} not displayed",
+                    s = if not_rendered_items > 1 { "s" } else { "" }
+                ),
             )
         } else {
             theme.format_footer(&state.into())

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -8,11 +8,11 @@ use crate::{
     theme::THEME,
 };
 
-pub struct Checkbox<T> {
-    pub value: T,
-    pub label: String,
-    pub hint: String,
-    pub selected: bool,
+struct Checkbox<T> {
+    value: T,
+    label: String,
+    hint: String,
+    selected: bool,
 }
 
 /// A prompt that asks for one or more selections from a list of options.

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,11 +1,15 @@
-use std::fmt::Display;
+use std::cell::RefCell;
 use std::io;
+use std::{fmt::Display, rc::Rc};
 
 use console::Key;
 
 use crate::{
-    prompt::cursor::StringCursor,
-    prompt::interaction::{Event, PromptInteraction, State},
+    filter::{FilteredView, LabeledItem},
+    prompt::{
+        cursor::StringCursor,
+        interaction::{Event, PromptInteraction, State},
+    },
     theme::THEME,
 };
 
@@ -16,13 +20,19 @@ struct RadioButton<T> {
     hint: String,
 }
 
+impl<T> LabeledItem for RadioButton<T> {
+    fn label(&self) -> &str {
+        &self.label
+    }
+}
+
 /// A prompt that asks for one selection from a list of options.
 pub struct Select<T> {
     prompt: String,
-    items: Vec<RadioButton<T>>,
+    items: Vec<Rc<RefCell<RadioButton<T>>>>,
     cursor: usize,
     initial_value: Option<T>,
-    filter_mode: Option<FilterMode<T>>,
+    filter: FilteredView<RadioButton<T>>,
 }
 
 impl<T> Select<T>
@@ -36,17 +46,17 @@ where
             items: Vec::new(),
             cursor: 0,
             initial_value: None,
-            filter_mode: None,
+            filter: FilteredView::default(),
         }
     }
 
     /// Adds an item to the selection prompt.
     pub fn item(mut self, value: T, label: impl Display, hint: impl Display) -> Self {
-        self.items.push(RadioButton {
+        self.items.push(Rc::new(RefCell::new(RadioButton {
             value,
             label: label.to_string(),
             hint: hint.to_string(),
-        });
+        })));
         self
     }
 
@@ -64,9 +74,9 @@ where
         self
     }
 
-    /// Enable the filter mode
+    /// Enable the filter mode.
     pub fn filter_mode(mut self) -> Self {
-        self.filter_mode = Some(FilterMode::new(self.items.clone()));
+        self.filter.enable();
         self
     }
 
@@ -82,9 +92,10 @@ where
             self.cursor = self
                 .items
                 .iter()
-                .position(|item| item.value == *initial_value)
+                .position(|item| item.borrow().value == *initial_value)
                 .unwrap_or(self.cursor);
         }
+        self.filter.set(self.items.to_vec());
         <Self as PromptInteraction<T>>::interact(self)
     }
 }
@@ -93,31 +104,26 @@ impl<T: Clone> PromptInteraction<T> for Select<T> {
     fn on(&mut self, event: &Event) -> State<T> {
         let Event::Key(key) = event;
 
-        if let Some(filter) = &mut self.filter_mode {
-            if let Some(state) = filter.on(key, &self.items) {
-                return state;
+        if let Some(state) = self.filter.on(key, self.items.clone()) {
+            if self.filter.items().is_empty() || self.cursor > self.filter.items().len() - 1 {
+                self.cursor = 0;
             }
+            return state;
         }
-
-        let (cursor, items) = if let Some(filter) = &mut self.filter_mode {
-            (&mut filter.cursor, &filter.items)
-        } else {
-            (&mut self.cursor, &self.items)
-        };
 
         match key {
             Key::ArrowUp | Key::ArrowLeft => {
-                if *cursor > 0 {
-                    *cursor -= 1;
+                if self.cursor > 0 {
+                    self.cursor -= 1;
                 }
             }
             Key::ArrowDown | Key::ArrowRight => {
-                if !items.is_empty() && *cursor < items.len() - 1 {
-                    *cursor += 1;
+                if !self.filter.items().is_empty() && self.cursor < self.filter.items().len() - 1 {
+                    self.cursor += 1;
                 }
             }
             Key::Enter => {
-                return State::Submit(items[*cursor].value.clone());
+                return State::Submit(self.filter.items()[self.cursor].borrow().value.clone());
             }
             _ => {}
         }
@@ -131,103 +137,32 @@ impl<T: Clone> PromptInteraction<T> for Select<T> {
         let header_display = theme.format_header(&state.into(), &self.prompt);
         let footer_display = theme.format_footer(&state.into());
 
-        let filter_display = if let Some(filter) = &self.filter_mode {
+        let filter_display = if let Some(input) = &self.filter.input() {
             match state {
                 State::Submit(_) | State::Cancel => "".to_string(),
-                _ => theme.format_input(&state.into(), &filter.input),
+                _ => theme.format_input(&state.into(), input),
             }
         } else {
             "".to_string()
         };
 
-        let (items, cursor) = if let Some(filter) = &self.filter_mode {
-            (&filter.items, filter.cursor)
-        } else {
-            (&self.items, self.cursor)
-        };
-
-        let items_display: String = items
+        let items_display: String = self
+            .filter
+            .items()
             .iter()
             .enumerate()
             .map(|(i, item)| {
-                theme.format_select_item(&state.into(), cursor == i, &item.label, &item.hint)
+                let item = item.borrow();
+                theme.format_select_item(&state.into(), self.cursor == i, &item.label, &item.hint)
             })
             .collect();
 
         header_display + &filter_display + &items_display + &footer_display
     }
 
-    /// Handles the input cursor automatically in the filter mode.
+    /// Enable handling of the input in the filter mode.
     fn input(&mut self) -> Option<&mut StringCursor> {
-        self.filter_mode.as_mut().map(|filter| &mut filter.input)
-    }
-}
-
-struct FilterMode<T> {
-    input: StringCursor,
-    items: Vec<RadioButton<T>>,
-    cursor: usize,
-}
-
-impl<T: Clone> FilterMode<T> {
-    fn new(items: Vec<RadioButton<T>>) -> Self {
-        Self {
-            input: StringCursor::default(),
-            items,
-            cursor: 0,
-        }
-    }
-
-    fn on(&mut self, key: &Key, all_items: &[RadioButton<T>]) -> Option<State<T>> {
-        match key {
-            // Need further processing of simple up and down actions.
-            Key::ArrowDown | Key::ArrowUp => None,
-            // Need moving up and down the list if no input provided.
-            Key::ArrowLeft | Key::ArrowRight if self.input.is_empty() => None,
-            // Need submitting of the selected item.
-            Key::Enter if !self.items.is_empty() => None,
-            // Otherwise, no items found.
-            Key::Enter => Some(State::Error("No items".into())),
-            // Refresh the filtered items for the rest of the keys.
-            _ if !self.input.is_empty() => {
-                let input_lower = self.input.to_string();
-                let filter_words: Vec<_> = input_lower.split_whitespace().collect();
-
-                let mut filtered_and_scored_items: Vec<_> = all_items
-                    .iter()
-                    .map(|item| {
-                        let similarity = strsim::jaro_winkler(
-                            &item.label.to_lowercase(),
-                            &self.input.to_string().to_lowercase(),
-                        );
-                        let bonus = filter_words
-                            .iter()
-                            .all(|word| item.label.to_lowercase().contains(&word.to_lowercase()))
-                            as usize as f64;
-                        (similarity + bonus, item)
-                    })
-                    .filter(|(similarity, _)| *similarity > 0.6)
-                    .collect();
-
-                filtered_and_scored_items.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
-
-                self.items = filtered_and_scored_items
-                    .into_iter()
-                    .map(|(_, item)| item.clone())
-                    .collect();
-
-                if self.items.is_empty() || self.cursor > self.items.len() - 1 {
-                    self.cursor = 0;
-                }
-
-                Some(State::Active)
-            }
-            // Reset the items to the original list.
-            _ => {
-                self.items = all_items.to_vec();
-                Some(State::Active)
-            }
-        }
+        self.filter.input()
     }
 }
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -112,7 +112,7 @@ impl<T: Clone> PromptInteraction<T> for Select<T> {
                 }
             }
             Key::ArrowDown | Key::ArrowRight => {
-                if *cursor < items.len() - 1 {
+                if !items.is_empty() && *cursor < items.len() - 1 {
                     *cursor += 1;
                 }
             }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -286,10 +286,15 @@ pub trait Theme {
 
     /// Formats the footer of the prompt (like `└  Operation cancelled.`).
     fn format_footer(&self, state: &ThemeState) -> String {
+        self.format_footer_with_message(state, "")
+    }
+
+    /// Formats the footer with a custom message (like `└  {message}`).
+    fn format_footer_with_message(&self, state: &ThemeState, message: &str) -> String {
         format!(
             "{}\n", // '\n' vanishes by style applying, thus exclude it from styling
             self.bar_color(state).apply_to(match state {
-                ThemeState::Active => format!("{S_BAR_END}"),
+                ThemeState::Active => format!("{S_BAR_END}  {message}"),
                 ThemeState::Cancel => format!("{S_BAR_END}  Operation cancelled."),
                 ThemeState::Submit => format!("{S_BAR}"),
                 ThemeState::Error(err) => format!("{S_BAR_END}  {err}"),


### PR DESCRIPTION
Continuation of feature #6 

1. Dissect filtering logic to the `FilterMode` implementation.
2. Move filtering to the `on()` event handling.
3. Make `RadioButton` and `Checkbox` private (not sure why they were `pub`).
4. The list is always rendered through the `self.filter`.
5. `Rc<RefCell>` is to handle a subset of filtered mutable references to the items from the same structure.

![image](https://github.com/fadeevab/cliclack/assets/5967447/65bf0f5a-f762-4edf-a6f7-0a78ff7f61ce)
![image](https://github.com/fadeevab/cliclack/assets/5967447/7e6258c0-5b2d-4c5b-a475-7f70b1cec76b)
![image](https://github.com/fadeevab/cliclack/assets/5967447/88f1d655-b64e-45c8-8e8f-a1a595adf11c)

