### PR TITLE
Fix multi-progress bar stopping with cleared spinner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/fadeevab/cliclack"
 
 [dependencies]
 console = "0.15.8"
-indicatif = "0.17.5"
+indicatif = "0.17.8"
 once_cell = "1.18.0"
 textwrap = "0.16.0"
 zeroize = {version = "1.6.0", features = ["derive"]}

--- a/src/multiprogress.rs
+++ b/src/multiprogress.rs
@@ -77,11 +77,6 @@ impl MultiProgress {
 
         // Redraw all progress bars.
         for pb in self.bars.read().unwrap().iter() {
-            // Ignore cleared (hidden and stopped) progress bars.
-            if pb.bar.message().is_empty() && pb.options().stopped {
-                continue;
-            }
-
             // Workaround: `bar.println` must be called before `bar.finish_and_clear`
             // to avoid lines "jumping" while terminal resizing.
             inner_height += pb.redraw_finished(pb.bar.message(), state);

--- a/src/multiprogress.rs
+++ b/src/multiprogress.rs
@@ -77,6 +77,11 @@ impl MultiProgress {
 
         // Redraw all progress bars.
         for pb in self.bars.read().unwrap().iter() {
+            // Ignore cleared (hidden and stopped) progress bars.
+            if pb.bar.message().is_empty() && pb.options().stopped {
+                continue;
+            }
+
             // Workaround: `bar.println` must be called before `bar.finish_and_clear`
             // to avoid lines "jumping" while terminal resizing.
             inner_height += pb.redraw_finished(pb.bar.message(), state);

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -158,7 +158,10 @@ impl ProgressBar {
             state,
         );
 
-        self.bar.println(msg.clone());
+        // Ignore a cleared progress bar.
+        if !msg.is_empty() {
+            self.bar.println(msg.clone());
+        }
 
         msg.lines().count()
     }


### PR DESCRIPTION
The problem is reproduced after `spinner.clear()` in the multi-progress bar.

Problem:
![image](https://github.com/fadeevab/cliclack/assets/5967447/bdf9938a-cd72-4cf8-93a8-4841fa37ae66)


Fix:
![image](https://github.com/fadeevab/cliclack/assets/5967447/e4c134b0-f212-426f-b85a-374a70591044)
