### PR TITLE
improve/multiline-double-esc

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -196,6 +196,7 @@ where
             Key::Char(c) if !c.is_ascii_control() && self.multiline == Multiline::Preview => {
                 self.input.insert(*c);
             }
+            Key::Backspace => self.input.delete_left(),
             _ => {}
         }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -251,8 +251,8 @@ where
         let part3 = theme.format_footer_with_message(
             &state.into(),
             match self.multiline {
-                Multiline::Editing => "[Esc]: preview",
-                Multiline::Preview => "[Enter]: submit",
+                Multiline::Editing => "[Esc](Preview)",
+                Multiline::Preview => "[Enter](Submit)",
                 _ => "",
             },
         );


### PR DESCRIPTION
- BackSpace also works in Preview Mode. 
- change the Hint from `[ESC]: preview` to `[ESC](Preview)`. It looks like markdown, and many uses `[xx]` to wrap a key. 