### PR TITLE
Re-export of the `StringCursor` to support overriding some `Theme` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,8 +271,11 @@ use std::io;
 
 use theme::THEME;
 
-// 🎨 Re-export of the theme API.
+
+// 🎨 Export of the theme API.
 pub use theme::{reset_theme, set_theme, Theme, ThemeState};
+// 🎨 Re-export for some `Theme` trait methods.
+pub use prompt::cursor::StringCursor;
 
 pub use confirm::Confirm;
 pub use input::Input;

--- a/src/prompt/cursor.rs
+++ b/src/prompt/cursor.rs
@@ -2,6 +2,10 @@ use std::fmt::{Display, Formatter, Result};
 
 use zeroize::ZeroizeOnDrop;
 
+/// A cursor for editing multiline strings.
+///
+/// Supports moving the cursor (left, right, up, down), backspace, delete, etc.
+#[doc(hidden)]
 #[derive(Default, ZeroizeOnDrop, Clone)]
 pub struct StringCursor {
     value: Vec<char>,


### PR DESCRIPTION
It should fix the issue #67 