### PR TITLE
implementation of implicit optional for input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ indicatif = "0.17.8"
 once_cell = "1.18.0"
 strsim = "0.11.1"
 textwrap = "0.16.0"
+thiserror = "1.0.63"
 zeroize = {version = "1.6.0", features = ["derive"]}
 
 [dev-dependencies]

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -22,6 +22,14 @@ fn main() -> std::io::Result<()> {
 
     log::remark(&format!("You entered: {:?}", email))?;
 
+    // But we can still use `required(true)` with an `Option<>` return type if we want...
+    // Don't know why you would, but you can.
+    let age: Option<i32> = cliclack::input("How old are you (required)?")
+        .required(true)
+        .interact()?;
+
+    log::remark(&format!("You entered: {:?}", age))?;
+
     // This case shows bad usage:
     // - The result will never be empty due to `default_input()` being set, so 
     //   `required()` has no effect. 

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,21 +1,19 @@
 use cliclack::log;
 
 fn main() -> std::io::Result<()> {
-    // This case requires input will never return an empty string.
+    // This case demonstrates the default behavior of `input()` when a non-`Option<>`
+    // return type is used, i.e. `required(true)`.
     let name: String = cliclack::input("What's your name (required)?")
         .interact()?;
 
     log::remark(&format!("You entered: {}", name))?;
 
-    // This case does not require input. The result will be `None` if the user 
-    // does not provide any input (i.e. just presses <enter>), and `Some(18)` 
-    // if the user provides "18".
-    let age: Option<i32> = cliclack::input("How old are you (optional)?")
-        .placeholder("18")
-        .required(false)
+    // This case demonstrates the implicit behavior of `input()` when the return 
+    // type is an `Option<T>`, i.e. `required(false)`.
+    let email: Option<String> = cliclack::input("What's your email (optional)?")
         .interact()?;
 
-    log::remark(&format!("You entered: {:?}", age))?;
+    log::remark(&format!("You entered: {:?}", email))?;
 
     // This case shows bad usage:
     // - The result will never be empty due to `default_input()` being set, so 

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,34 @@
+use cliclack::log;
+
+fn main() -> std::io::Result<()> {
+    // This case requires input will never return an empty string.
+    let name: String = cliclack::input("What's your name (required)?")
+        .interact()?;
+
+    log::remark(&format!("You entered: {}", name))?;
+
+    // This case does not require input. The result will be `None` if the user 
+    // does not provide any input (i.e. just presses <enter>), and `Some(18)` 
+    // if the user provides "18".
+    let age: Option<i32> = cliclack::input("How old are you (optional)?")
+        .placeholder("18")
+        .required(false)
+        .interact()?;
+
+    log::remark(&format!("You entered: {:?}", age))?;
+
+    // This case shows bad usage:
+    // - The result will never be empty due to `default_input()` being set, so 
+    //   `required()` has no effect. 
+    // - The `Option<>` return type is superfluous as it will never return `None`
+    //   due to `default_input()` being set.
+    let desc: Option<String> = cliclack::input("How would you describe cliclack?")
+        .placeholder("Awesome!")
+        .required(true) // This is not required because the result will never be empty due to `default_input()` being set.
+        .default_input("Awesome!")
+        .interact()?;
+
+    log::remark(&format!("You entered: {:?}", desc))?;
+
+    Ok(())
+}

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -8,6 +8,13 @@ fn main() -> std::io::Result<()> {
 
     log::remark(&format!("You entered: {}", name))?;
 
+    // We can still use `required(false)` with a non-`Option<>` return type, of course.
+    let city: String = cliclack::input("What city do you live in (optional)?")
+        .required(false)
+        .interact()?;
+
+    log::remark(&format!("You entered: {}", city))?;
+
     // This case demonstrates the implicit behavior of `input()` when the return 
     // type is an `Option<T>`, i.e. `required(false)`.
     let email: Option<String> = cliclack::input("What's your email (optional)?")

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+//! Error types for CliClack.
+
+use std::io;
+
+use thiserror::Error;
+
+/// Error type for CLI prompts.
+#[derive(Debug, Error)]
+pub enum CliError {
+    /// I/O error.
+    #[error("i/o error: {0}")]
+    Io(io::Error),
+    /// Error parsing a string to a target type.
+    #[error("parse error: {0}")]
+    Parse(String),
+    /// Validation error.
+    #[error("validation error: {0}")]
+    Validate(String),
+}
+
+impl Into<io::Error> for CliError {
+    fn into(self) -> io::Error {
+        match self {
+            CliError::Io(err) => err,
+            CliError::Parse(msg) => io::Error::new(io::ErrorKind::InvalidInput, msg),
+            CliError::Validate(msg) => io::Error::new(io::ErrorKind::InvalidInput, msg),
+        }
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,10 @@
 use std::io;
-use std::{fmt::Display, str::FromStr};
+use std::fmt::Display;
 
 use console::Key;
 
 use crate::{
+    parse::CliFromStr,
     prompt::{
         cursor::StringCursor,
         interaction::{Event, PromptInteraction, State},
@@ -144,7 +145,7 @@ impl Input {
     /// Starts the prompt interaction.
     pub fn interact<T>(&mut self) -> io::Result<T>
     where
-        T: FromStr,
+        T: CliFromStr,
     {
         if self.placeholder.is_empty() {
             if let Some(default) = &self.default {
@@ -163,7 +164,7 @@ impl Input {
 
 impl<T> PromptInteraction<T> for Input
 where
-    T: FromStr,
+    T: CliFromStr,
 {
     fn input(&mut self) -> Option<&mut StringCursor> {
         if self.multiline == Multiline::Preview {
@@ -215,7 +216,7 @@ where
                 return State::Error(err);
             }
 
-            if self.input.to_string().parse::<T>().is_err() {
+            if T::try_parse(&self.input.to_string()).is_err() {
                 return State::Error("Invalid value format".to_string());
             }
         }
@@ -227,7 +228,7 @@ where
                 }
             }
 
-            match self.input.to_string().parse::<T>() {
+            match T::try_parse(&self.input.to_string()) {
                 Ok(value) => return State::Submit(value),
                 Err(_) => return State::Error("Invalid value format".to_string()),
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 
 use console::Key;
 
+use crate::option::is_option;
 use crate::{
     parse::CliFromStr,
     prompt::{
@@ -143,7 +144,7 @@ impl Input {
     }
 
     /// Starts the prompt interaction.
-    pub fn interact<T>(&mut self) -> io::Result<T>
+    pub fn interact<T: CliFromStr + Default>(&mut self) -> io::Result<T>
     where
         T: CliFromStr,
     {
@@ -164,7 +165,7 @@ impl Input {
 
 impl<T> PromptInteraction<T> for Input
 where
-    T: CliFromStr,
+    T: CliFromStr + Default,
 {
     fn input(&mut self) -> Option<&mut StringCursor> {
         if self.multiline == Multiline::Preview {
@@ -206,6 +207,8 @@ where
         if submit && self.input.is_empty() {
             if let Some(default) = &self.default {
                 self.input.extend(default);
+            } else if is_option::<T>() {
+                return State::Submit(T::default())
             } else if self.input_required {
                 return State::Error("Input required".to_string());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,8 +264,10 @@ mod prompt;
 mod select;
 mod theme;
 mod validate;
+mod parse;
 
 use console::Term;
+use thiserror::Error;
 use std::fmt::Display;
 use std::io;
 
@@ -285,6 +287,20 @@ pub use password::Password;
 pub use progress::ProgressBar;
 pub use select::Select;
 pub use validate::Validate;
+
+/// Error type for CLI prompts.
+#[derive(Debug, Error)]
+pub enum CliError {
+    /// I/O error.
+    #[error("i/o error: {0}")]
+    Io(io::Error),
+    /// Error parsing a string to a target type.
+    #[error("parse error: {0}")]
+    Parse(String),
+    /// Validation error.
+    #[error("validation error: {0}")]
+    Validate(String),
+}
 
 fn term_write(line: impl Display) -> io::Result<()> {
     Term::stderr().write_str(line.to_string().as_str())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,9 +265,11 @@ mod select;
 mod theme;
 mod validate;
 mod parse;
+mod option;
+
+pub mod error;
 
 use console::Term;
-use thiserror::Error;
 use std::fmt::Display;
 use std::io;
 
@@ -287,20 +289,6 @@ pub use password::Password;
 pub use progress::ProgressBar;
 pub use select::Select;
 pub use validate::Validate;
-
-/// Error type for CLI prompts.
-#[derive(Debug, Error)]
-pub enum CliError {
-    /// I/O error.
-    #[error("i/o error: {0}")]
-    Io(io::Error),
-    /// Error parsing a string to a target type.
-    #[error("parse error: {0}")]
-    Parse(String),
-    /// Validation error.
-    #[error("validation error: {0}")]
-    Validate(String),
-}
 
 fn term_write(line: impl Display) -> io::Result<()> {
     Term::stderr().write_str(line.to_string().as_str())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,7 @@ mod option;
 pub mod error;
 
 use console::Term;
+use parse::CliFromStr;
 use std::fmt::Display;
 use std::io;
 
@@ -333,7 +334,7 @@ pub fn outro_note(prompt: impl Display, message: impl Display) -> io::Result<()>
 /// Constructs a new [`Input`] prompt.
 ///
 /// See [`Input`] for chainable methods.
-pub fn input(prompt: impl Display) -> Input {
+pub fn input<T: CliFromStr + Default>(prompt: impl Display) -> Input<T> {
     Input::new(prompt)
 }
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,0 +1,59 @@
+use std::{cell::Cell, marker::PhantomData};
+
+use crate::parse::CliFromStr;
+
+/// Marker trait for `Option<>` types.
+#[allow(unused)]
+pub trait IsOptionMarker { }
+
+/// Implement `IsOptionMarker` for `Option<T>` where `T` implements `CliFromStr`.
+impl<T: CliFromStr> IsOptionMarker for Option<T> { }
+
+/// A helper struct to determine if a type is an `Option<>`.
+pub(crate) struct IsOption<'a, T> 
+where 
+    T: CliFromStr 
+{
+    is_option: &'a Cell<bool>,
+    _marker: PhantomData<T>,
+}
+
+impl<'a, T> Clone for IsOption<'a, T> 
+where 
+    T: CliFromStr 
+{
+    fn clone(&self) -> Self {
+        self.is_option.set(false);
+        IsOption {
+            is_option: self.is_option,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: IsOptionMarker + CliFromStr> Copy for IsOption<'_, T> {}
+
+/// Determine if a type is an `Option<T: CliFromStr>`.
+pub fn is_option<T>() -> bool 
+where 
+    T: CliFromStr 
+{
+    let is_option = Cell::new(true);
+    let _ = [IsOption::<T> {
+        is_option: &is_option,
+        _marker: PhantomData,
+    }]
+    .clone();
+    is_option.get()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_option() {
+        assert_eq!(is_option::<Option<i32>>(), true);
+        assert_eq!(is_option::<i32>(), false);
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
-use crate::CliError;
+use crate::error::CliError;
 
 /// A trait for parsing a type from a string. This is similar to `FromStr`, but
 /// is a trait we can implement for types we don't own.
@@ -63,6 +63,7 @@ impl<T: CliFromStr> CliFromStr for Option<T> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
     use crate::parse::CliFromStr;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,86 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
+use crate::CliError;
+
+/// A trait for parsing a type from a string. This is similar to `FromStr`, but
+/// is a trait we can implement for types we don't own.
+pub trait CliFromStr: Sized {
+    fn try_parse(s: &str) -> Result<Self, CliError>;
+}
+
+/// Helper macro for implementing [`CliFromStr`] for a list of types that implement
+/// [`std::str::FromStr`].
+macro_rules! impl_for_fromstr {
+    ($($t:ty),*) => {
+        $(
+            impl CliFromStr for $t {
+                fn try_parse(s: &str) -> Result<Self, CliError> {
+                    s.parse().map_err(|_| CliError::Parse(s.to_string()))
+                }
+            }
+        )*
+    };
+}
+
+// Implement `CliFromStr` for all types that implement `FromStr`, which keeps
+// backwards compatibility.
+impl_for_fromstr!(
+    String, 
+    usize, 
+    isize, 
+    u128, 
+    u64, 
+    u32, 
+    u16, 
+    u8, 
+    i128, 
+    i64, 
+    i32, 
+    i16, 
+    i8, 
+    f64, 
+    f32, 
+    bool,
+    char,
+    IpAddr,
+    Ipv4Addr,
+    Ipv6Addr,
+    SocketAddrV4,
+    SocketAddrV6
+);
+
+/// Implement `CliFromStr` for `Option<T>` where `T` implements `CliFromStr`. This
+/// allows us to parse optional values for any type that implements `CliFromStr`.
+impl<T: CliFromStr> CliFromStr for Option<T> {
+    fn try_parse(s: &str) -> Result<Self, CliError> {
+        if s.is_empty() {
+            Ok(None)
+        } else {
+            T::try_parse(s)
+                .map_err(|_| CliError::Parse(s.to_string()))
+                .map(Some)
+        }
+    }
+}
+
+mod tests {
+    #[allow(unused_imports)]
+    use crate::parse::CliFromStr;
+
+    #[test]
+    fn parse_string() {
+        assert_eq!(String::try_parse("hello").unwrap(), "hello".to_string());
+    }
+
+    #[test]
+    fn parse_optional_string() {
+        assert_eq!(Option::<String>::try_parse("").unwrap(), None);
+        assert_eq!(Option::<String>::try_parse("hello").unwrap(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn parse_optional_integer() {
+        assert_eq!(Option::<usize>::try_parse("").unwrap(), None);
+        assert_eq!(Option::<usize>::try_parse("123").unwrap(), Some(123));
+    }
+}


### PR DESCRIPTION
@fadeevab what do you think of something like this for making better use of `Option<T>`? This basically obsoletes `required()` in favor of either using (or not using) an `Option<>` to specify whether or not the field is required. See the `input.rs` example file for usage.

Should be 99% backwards-compatible, with an exception for anyone who has implemented `FromStr` for custom types and use them together with `input()` -- they'd need to change that to `CliFromStr` (trivial).

This change would opinionate that `""` == `Option::None` when the return value is an `Option<T>`.

Related to #68 