### PR TITLE
add support for windowing in select

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ console = "0.15.8"
 indicatif = "0.17.8"
 once_cell = "1.18.0"
 strsim = "0.11.1"
+termsize = "0.1.9"
 textwrap = "0.16.0"
 zeroize = {version = "1.6.0", features = ["derive"]}
 

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -1,0 +1,23 @@
+fn main() -> std::io::Result<()> {
+    let mut items: Vec<(String, String, String)> = Vec::new();
+
+    for i in 0..20 {
+        items.push((
+            format!("Item {}", i),
+            i.to_string(),
+            format!("Hint {}", i),
+        ));
+    }
+
+    // Try this example with a terminal height both less than and greater than 10
+    // to see the automatic window-size adjustment.
+    let selected = cliclack::select("Select an item")
+        .items(&items)
+        .window_size(10) // Specify a custom window-size
+        .filter_mode() // Try filtering on "1"
+        .interact()?;
+
+    cliclack::outro(format!("You selected: {}", selected))?;
+
+    Ok(())
+}

--- a/examples/select_window_size.rs
+++ b/examples/select_window_size.rs
@@ -1,0 +1,21 @@
+fn main() -> std::io::Result<()> {
+    let mut items: Vec<(String, String, String)> = Vec::new();
+
+    for i in 0..20 {
+        items.push((
+            format!("Item {}", i),
+            i.to_string(),
+            format!("Hint {}", i),
+        ));
+    }
+
+    let selected = cliclack::select("Select an item")
+        .items(&items)
+        .window_size(5)
+        .filter_mode() // Try filtering on "1"
+        .interact()?;
+
+    cliclack::outro(format!("You selected: {}", selected))?;
+
+    Ok(())
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -25,18 +25,27 @@ impl<I: LabeledItem> Default for FilteredView<I> {
 }
 
 impl<I: LabeledItem + Clone> FilteredView<I> {
+    /// Enable filtering of the items in the view.
     pub fn enable(&mut self) {
         self.enabled = true;
     }
 
+    /// Set the items to be filtered.
     pub fn set(&mut self, items: Vec<Rc<RefCell<I>>>) {
         self.items = items;
     }
 
+    /// Return the filtered items in the view.
     pub fn items(&self) -> &[Rc<RefCell<I>>] {
         &self.items
     }
 
+    /// Get whether or not filtering is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Handle the key event and update the state of the view.
     pub fn on<T>(&mut self, key: &Key, all_items: Vec<Rc<RefCell<I>>>) -> Option<State<T>> {
         if !self.enabled {
             // Pass over the control.


### PR DESCRIPTION
Offers a solution for #64 by allowing the user to specify a max window size -- works with filtering as well. See the `select_window_size` example.

An ultimate solution would probably use something like [termsize](https://github.com/softprops/termsize) and calculate based on the actual size of the viewport.