### PR TITLE
feat(multiprogress): add `println` and `insert` functions

### DIFF
--- a/src/multiprogress.rs
+++ b/src/multiprogress.rs
@@ -92,7 +92,10 @@ impl MultiProgress {
         self.stop_with(&ThemeState::Error(error.to_string()))
     }
 
-    /// Print a log line above the multi-progress, optionally followed by an empty line
+    /// Print a log line above the multi-progress
+    ///
+    /// By default, there is no empty line between each log added with this function. To add an empty line, use a line
+    /// return character (`\n`) at the end of the message.
     pub fn println(&self, message: impl Display) {
         let theme = THEME.lock().unwrap();
         let symbol = theme.remark_symbol();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -656,8 +656,17 @@ pub trait Theme {
 
     /// Returns a log message rendering with a chosen symbol.
     fn format_log(&self, text: &str, symbol: &str) -> String {
+        self.format_log_with_spacing(text, symbol, true)
+    }
+
+    /// Returns a log message rendering with a chosen symbol, with an optional trailing empty line
+    fn format_log_with_spacing(&self, text: &str, symbol: &str, spacing: bool) -> String {
         let mut parts = vec![];
-        let mut lines = text.lines().chain("\n".lines());
+        let chain = match spacing {
+            true => "\n",
+            false => "",
+        };
+        let mut lines = text.lines().chain(chain.lines());
 
         if let Some(first) = lines.next() {
             parts.push(format!("{symbol}  {first}"));


### PR DESCRIPTION
This PR adds two functions to the `MultiProgress` object:

- `println(message)`: this function allows to add a log message (with the "remark" symbol) to the multiprogress, which will show above the progress bars.
- `insert(index, pb)`: this function allows to insert a progress bar at any index into the list of existing progress bars. This allows to put the new item at the top or in the middle of existing progress bars.

Closes #74 