### PR TITLE
Added accounting for terminal size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ textwrap = "0.16.0"
 zeroize = {version = "1.6.0", features = ["derive"]}
 termsize = "0.1"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 ctrlc = "3.4.2"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ once_cell = "1.18.0"
 strsim = "0.11.1"
 textwrap = "0.16.0"
 zeroize = {version = "1.6.0", features = ["derive"]}
+termsize = "0.1"
 
 [dev-dependencies]
 ctrlc = "3.4.2"

--- a/examples/window_rows.rs
+++ b/examples/window_rows.rs
@@ -9,7 +9,7 @@ fn main() -> std::io::Result<()> {
     // to see the automatic window-size adjustment.
     let selected = cliclack::select("Select an item")
         .items(&items)
-        .set_size(10) // Specify a custom window-size
+        .set_max_rows(10) // Specify a custom window-size
         .filter_mode() // Try filtering on "1"
         .interact()?;
 

--- a/examples/window_size.rs
+++ b/examples/window_size.rs
@@ -1,0 +1,19 @@
+fn main() -> std::io::Result<()> {
+    let mut items: Vec<(String, String, String)> = Vec::new();
+
+    for i in 0..20 {
+        items.push((format!("Item {}", i), i.to_string(), format!("Hint {}", i)));
+    }
+
+    // Try this example with a terminal height both less than and greater than 10
+    // to see the automatic window-size adjustment.
+    let selected = cliclack::select("Select an item")
+        .items(&items)
+        .window_size(10) // Specify a custom window-size
+        .filter_mode() // Try filtering on "1"
+        .interact()?;
+
+    cliclack::outro(format!("You selected: {}", selected))?;
+
+    Ok(())
+}

--- a/examples/window_size.rs
+++ b/examples/window_size.rs
@@ -9,7 +9,7 @@ fn main() -> std::io::Result<()> {
     // to see the automatic window-size adjustment.
     let selected = cliclack::select("Select an item")
         .items(&items)
-        .window_size(10) // Specify a custom window-size
+        .set_size(10) // Specify a custom window-size
         .filter_mode() // Try filtering on "1"
         .interact()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@
 //! cargo run --example theme
 //! ```
 
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![warn(missing_docs, unused_qualifications)]
 
 mod confirm;

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -92,15 +92,16 @@ where
     ///
     /// The filter mode allows to filter the items by typing.
     pub fn filter_mode(mut self) -> Self {
-        let term_size = self.term.get_size();
-        self.term.set_size(term_size.checked_sub(1).unwrap_or(term_size));
+        let term_size = self.term.get_max_rows();
+        self.term
+            .set_max_rows(term_size.checked_sub(1).unwrap_or(term_size));
         self.filter.enable();
         self
     }
 
-    /// Set the max number of items that are able to be displayed at once
-    pub fn set_size(mut self, size: usize) -> Self {
-        self.term.set_size(size);
+    /// Set the max number of rows of items that are able to be displayed at once
+    pub fn set_max_rows(mut self, size: usize) -> Self {
+        self.term.set_max_rows(size);
         self
     }
 
@@ -150,8 +151,8 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
                     self.cursor += 1;
                 }
 
-                if self.cursor >= self.term.get_pos() + self.term.get_size() {
-                    self.term.set_pos(self.cursor - self.term.get_size() + 1);
+                if self.cursor >= self.term.get_pos() + self.term.get_max_rows() {
+                    self.term.set_pos(self.cursor - self.term.get_max_rows() + 1);
                 }
             }
             Key::Char(' ') => {
@@ -209,7 +210,7 @@ impl<T: Clone> PromptInteraction<Vec<T>> for MultiSelect<T> {
             .map(|i| i.borrow())
             .enumerate()
             .skip(self.term.get_pos())
-            .take(self.term.get_size())
+            .take(self.term.get_max_rows())
         {
             items_render.push_str(&theme.format_multiselect_item(
                 &state.into(),

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -92,7 +92,8 @@ where
     ///
     /// The filter mode allows to filter the items by typing.
     pub fn filter_mode(mut self) -> Self {
-        self.term.set_size(self.term.get_size() - 1);
+        let term_size = self.term.get_size();
+        self.term.set_size(term_size.checked_sub(1).unwrap_or(term_size));
         self.filter.enable();
         self
     }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1,2 +1,3 @@
 pub mod cursor;
 pub mod interaction;
+pub mod term;

--- a/src/prompt/term.rs
+++ b/src/prompt/term.rs
@@ -1,30 +1,32 @@
 pub(crate) struct TermSize {
-    window_size: usize,
+    window_max_rows: usize,
     window_pos: usize,
 }
 
 impl Default for TermSize {
     fn default() -> Self {
-        let mut window_size = usize::MAX;
+        let mut window_max_rows = usize::MAX;
 
         if let Some(termsize) = termsize::get() {
-            window_size = (termsize.rows as usize).checked_sub(3).unwrap_or(termsize.rows as usize);
+            window_max_rows = (termsize.rows as usize)
+                .checked_sub(3)
+                .unwrap_or(termsize.rows as usize);
         }
 
         Self {
-            window_size,
+            window_max_rows,
             window_pos: 0,
         }
     }
 }
 
 impl TermSize {
-    pub fn get_size(&self) -> usize {
-        self.window_size
+    pub fn get_max_rows(&self) -> usize {
+        self.window_max_rows
     }
 
-    pub fn set_size(&mut self, size: usize) {
-        self.window_size = size;
+    pub fn set_max_rows(&mut self, rows: usize) {
+        self.window_max_rows = rows;
     }
 
     pub fn get_pos(&self) -> usize {

--- a/src/prompt/term.rs
+++ b/src/prompt/term.rs
@@ -1,0 +1,37 @@
+pub(crate) struct TermSize {
+    window_size: usize,
+    window_pos: usize,
+}
+
+impl Default for TermSize {
+    fn default() -> Self {
+        let mut window_size = usize::MAX;
+
+        if let Some(termsize) = termsize::get() {
+            window_size = termsize.rows as usize - 3;
+        }
+
+        Self {
+            window_size,
+            window_pos: 0,
+        }
+    }
+}
+
+impl TermSize {
+    pub fn get_size(&self) -> usize {
+        self.window_size
+    }
+
+    pub fn set_size(&mut self, size: usize) {
+        self.window_size = size;
+    }
+
+    pub fn get_pos(&self) -> usize {
+        self.window_pos
+    }
+
+    pub fn set_pos(&mut self, pos: usize) {
+        self.window_pos = pos;
+    }
+}

--- a/src/prompt/term.rs
+++ b/src/prompt/term.rs
@@ -7,7 +7,7 @@ impl Default for TermSize {
     fn default() -> Self {
         let mut window_max_rows = usize::MAX;
 
-        if let Some(termsize) = termsize::get() {
+        if let Some(termsize) = get_term_size() {
             window_max_rows = (termsize.rows as usize)
                 .checked_sub(3)
                 .unwrap_or(termsize.rows as usize);
@@ -35,5 +35,91 @@ impl TermSize {
 
     pub fn set_pos(&mut self, pos: usize) {
         self.window_pos = pos;
+    }
+}
+
+// IMPORTANT - Everything bellow this should be removed once
+// https://github.com/softprops/termsize/pull/24 is merged!
+// and the forbid unsafe rule should be reenabled!
+
+#[cfg(unix)]
+use std::io::IsTerminal;
+
+#[cfg(unix)]
+use std::ffi::{c_ushort, CString};
+
+#[cfg(unix)]
+use libc::{ioctl, O_RDONLY, STDOUT_FILENO, TIOCGWINSZ};
+
+/// A representation of the size of the current terminal
+#[repr(C)]
+#[derive(Debug)]
+#[cfg(unix)]
+pub struct UnixSize {
+    /// number of rows
+    pub rows: c_ushort,
+    /// number of columns
+    pub cols: c_ushort,
+    x: c_ushort,
+    y: c_ushort,
+}
+
+
+/// Workaround for SSH terminal size
+pub fn get_term_size() -> Option<termsize::Size> {
+    #[cfg(not(unix))]
+    {
+        termsize::get()
+    }
+
+    #[cfg(unix)]
+    {
+        _get_unix_termsize()
+    }
+}
+
+/// Gets the current terminal size
+#[cfg(unix)]
+fn _get_unix_termsize() -> Option<termsize::Size> {
+    // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
+    if !std::io::stdout().is_terminal() {
+        return None;
+    }
+    let mut us = UnixSize {
+        rows: 0,
+        cols: 0,
+        x: 0,
+        y: 0,
+    };
+
+    let fd = if let Ok(ssh_term) = std::env::var("SSH_TTY") {
+        // Convert path to a C-compatible string
+        let c_path = CString::new(ssh_term).expect("Failed to convert path to CString");
+
+        // Open the terminal device
+        let fd = unsafe { libc::open(c_path.as_ptr(), O_RDONLY) };
+        if fd < 0 {
+            return None; // Failed to open the terminal device
+        }
+
+        fd
+    } else {
+        STDOUT_FILENO
+    };
+
+    let r = unsafe { ioctl(fd, TIOCGWINSZ, &mut us) };
+
+    // Closing the open file descriptor
+    if fd != STDOUT_FILENO {
+        unsafe { libc::close(fd); }
+    }
+
+    if r == 0 {
+        Some(termsize::Size {
+            rows: us.rows,
+            cols: us.cols,
+        })
+    } else {
+        None
     }
 }

--- a/src/prompt/term.rs
+++ b/src/prompt/term.rs
@@ -8,7 +8,7 @@ impl Default for TermSize {
         let mut window_size = usize::MAX;
 
         if let Some(termsize) = termsize::get() {
-            window_size = termsize.rows as usize - 3;
+            window_size = (termsize.rows as usize).checked_sub(3).unwrap_or(termsize.rows as usize);
         }
 
         Self {

--- a/src/select.rs
+++ b/src/select.rs
@@ -81,7 +81,8 @@ where
     ///
     /// The filter mode allows to filter the items by typing.
     pub fn filter_mode(mut self) -> Self {
-        self.term.set_size(self.term.get_size() - 1);
+        let term_size = self.term.get_size();
+        self.term.set_size(term_size.checked_sub(1).unwrap_or(term_size as usize));
         self.filter.enable();
         self
     }

--- a/src/select.rs
+++ b/src/select.rs
@@ -81,15 +81,16 @@ where
     ///
     /// The filter mode allows to filter the items by typing.
     pub fn filter_mode(mut self) -> Self {
-        let term_size = self.term.get_size();
-        self.term.set_size(term_size.checked_sub(1).unwrap_or(term_size as usize));
+        let term_size = self.term.get_max_rows();
+        self.term
+            .set_max_rows(term_size.checked_sub(1).unwrap_or(term_size as usize));
         self.filter.enable();
         self
     }
 
-    /// Set the max number of items that are able to be displayed at once
-    pub fn set_size(mut self, size: usize) -> Self {
-        self.term.set_size(size);
+    /// Set the max number of rows of items that are able to be displayed at once
+    pub fn set_max_rows(mut self, size: usize) -> Self {
+        self.term.set_max_rows(size);
         self
     }
 
@@ -139,8 +140,8 @@ impl<T: Clone> PromptInteraction<T> for Select<T> {
                     self.cursor += 1;
                 }
 
-                if self.cursor >= self.term.get_pos() + self.term.get_size() {
-                    self.term.set_pos(self.cursor - self.term.get_size() + 1);
+                if self.cursor >= self.term.get_pos() + self.term.get_max_rows() {
+                    self.term.set_pos(self.cursor - self.term.get_max_rows() + 1);
                 }
             }
             Key::Enter => {
@@ -173,7 +174,7 @@ impl<T: Clone> PromptInteraction<T> for Select<T> {
             .iter()
             .enumerate()
             .skip(self.term.get_pos())
-            .take(self.term.get_size())
+            .take(self.term.get_max_rows())
             .map(|(i, item)| {
                 let item = item.borrow();
                 theme.format_select_item(&state.into(), self.cursor == i, &item.label, &item.hint)


### PR DESCRIPTION
Fixes #64 and #79, and is based upon work in #73, but just refined.

Adds one external API called `set_size` to modify the number of rows displayed at once for `select` and `multiselect`.

By default, this ensures that there are not more than the maximum possible rows displayed at once.