### PR TITLE
Added `length` (`multiprogress.rs`) and `set_position` (`progress.rs`) methods

### DIFF
--- a/examples/multiprogress.rs
+++ b/examples/multiprogress.rs
@@ -33,12 +33,14 @@ fn main() -> std::io::Result<()> {
 
     let pb1 = multi.add(progress_bar(500));
     let pb2 = multi.add(progress_bar(500));
+    let pb3 = multi.insert(multi.length() - 1, progress_bar(500));
 
     pb1.start("Downloading files...");
     pb2.start("Copying files...");
+    pb3.start("Verifying download...");
 
     // Simulate doing some stuff....
-    while !pb1.is_finished() || !pb2.is_finished() {
+    while !pb1.is_finished() || !pb2.is_finished() || !pb3.is_finished() {
         // Use a random timeout to simulate some work.
         let timeout = Duration::from_millis(thread_rng().gen_range(10..75));
 
@@ -51,6 +53,7 @@ fn main() -> std::io::Result<()> {
 
             pb1.cancel(format!("{} Downloading files", style("✘").red()));
             pb2.cancel(format!("{} Copying files", style("✘").red()));
+            pb3.cancel(format!("{} Verifying download", style("✘").red()));
             multi.cancel();
             return Ok(());
         }
@@ -61,10 +64,16 @@ fn main() -> std::io::Result<()> {
             pb1.stop(format!("{} Downloading files", style("✔").green()));
         }
 
-        if pb2.position() < pb2.length().unwrap() {
+        if pb3.position() < pb2.length().unwrap() {
             pb2.inc(thread_rng().gen_range(1..13));
         } else if !pb2.is_finished() {
             pb2.stop(format!("{} Copying files", style("✔").green()));
+        }
+
+        if pb3.position() < pb3.length().unwrap() {
+            pb3.set_position(pb3.position() + thread_rng().gen_range(1..16));
+        } else if !pb3.is_finished() {
+            pb3.stop(format!("{} Verifying download", style("✔").green()));
         }
     }
 

--- a/src/multiprogress.rs
+++ b/src/multiprogress.rs
@@ -44,7 +44,7 @@ impl MultiProgress {
     ///
     /// The progress bar will be positioned below all other bars in the [`MultiProgress`].
     pub fn add(&self, pb: ProgressBar) -> ProgressBar {
-        let bars_count = self.bars.read().unwrap().len();
+        let bars_count = self.length();
         self.insert(bars_count, pb)
     }
 
@@ -52,7 +52,7 @@ impl MultiProgress {
     ///
     /// If the index is greater than or equal to the number of progress bars, the bar is added to the end.
     pub fn insert(&self, index: usize, pb: ProgressBar) -> ProgressBar {
-        let bars_count = self.bars.read().unwrap().len();
+        let bars_count = self.length();
         let index = index.min(bars_count);
         if index == bars_count {
             // Unset the last flag for all other progress bars: it affects rendering.
@@ -75,6 +75,11 @@ impl MultiProgress {
         let pb = ProgressBar { bar, options };
         self.bars.write().unwrap().insert(index, pb.clone());
         pb
+    }
+
+    /// Returns the number of progress bars in the [`MultiProgress`].
+    pub fn length(&self) -> usize {
+        self.bars.read().unwrap().len()
     }
 
     /// Prints a log line above the multi-progress bar.

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -91,6 +91,11 @@ impl ProgressBar {
         self.bar.set_length(len);
     }
 
+    /// Sets the position of the progress bar.
+    pub fn set_position(&self, pos: u64) {
+        self.bar.set_position(pos);
+    }
+
     /// Starts the progress bar.
     pub fn start(&self, message: impl Display) {
         let theme = THEME.read().unwrap();


### PR DESCRIPTION
Add `length` method (`multiprogress.rs`):
- allows inserting a progress bar in a specific position, knowing the number of progress bars in the set.

Add `set_position` method (`progress.rs`)
- allows setting the position of a progress bar.