### PR TITLE
0.4.1: feat(prompt): add Emacs-style keybindings for navigation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliclack"
-version = "0.4.0"
+version = "0.4.1"
 
 authors = ["Alexander Fadeev <fadeevab.com@gmail.com>"]
 categories = ["command-line-interface"]

--- a/src/prompt/interaction.rs
+++ b/src/prompt/interaction.rs
@@ -109,6 +109,14 @@ pub trait PromptInteraction<T> {
                 }
 
                 Ok(key) => {
+                    // Emacs-style keybindings.
+                    let key = match key {
+                        Key::Char('\x01') => Key::Home,      // Ctrl-A
+                        Key::Char('\x05') => Key::End,       // Ctrl-E
+                        Key::Char('\x10') => Key::ArrowUp,   // Ctrl-P
+                        Key::Char('\x0e') => Key::ArrowDown, // Ctrl-N
+                        _ => key,
+                    };
                     let word_editing = self.allow_word_editing();
                     if let Some(cursor) = self.input() {
                         match key {


### PR DESCRIPTION
It should be safe to handle Emacs key bindings in a universal cross-platform way: `console` already handles the `Home` (Ctrl-A) and `End` (Ctrl-E) for `cfg(unix)` targets, and the control codes are pretty much well-known for the Emacs key bindings. Also, we know the narrow scope of the usage for TUI.