### PR TITLE
fix: cancel interact on ctrl+c

### DIFF
--- a/src/prompt/interaction.rs
+++ b/src/prompt/interaction.rs
@@ -98,7 +98,7 @@ pub trait PromptInteraction<T> {
                 _ => {}
             }
 
-            match term.read_key() {
+            match term.read_key_raw() {
                 Ok(Key::Escape) => {
                     state = State::Cancel;
 
@@ -107,6 +107,8 @@ pub trait PromptInteraction<T> {
                         state = State::Active;
                     }
                 }
+
+                Ok(Key::CtrlC) => state = State::Cancel,
 
                 Ok(key) => {
                     // Emacs-style keybindings.


### PR DESCRIPTION
Hi, 
when I am selecting something and hit ctrl+c, the cursor would not restore. This PR fixes it for me.

I tested it with this example:
```rust
fn main() -> std::io::Result<()> {
    cliclack::intro("Test ctrl+c")?;

    let _: &str = cliclack::select("Press ctrl+c")
        .item("a", "Option A", "")
        .item("b", "Option B", "")
        .item("c", "Option C", "")
        .interact()?;

    cliclack::outro("Done")?;
    Ok(())
}
```

Seems to be related to https://github.com/fadeevab/cliclack/issues/84